### PR TITLE
Fix table ordering element IDs

### DIFF
--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -460,7 +460,7 @@ $(document).ready(function () {
                     buildTableColumns(),
                     buildTableColumnNames(),
                     'Ethnicity',
-                    $('#ethnicity-as-row__column_order').val());
+                    $('#ethnicity-as-row__column-order').val());
             } else {
                 var all_table_columns = buildTableColumns().concat(buildEthnicityByColumnColumns());
                 tableObject = buildTableObject(buildDataWithPreset(preset, table_data, all_table_columns),
@@ -470,7 +470,7 @@ $(document).ready(function () {
                     $('#ethnicity-as-column__rows').val(),
                     '',
                     'Ethnicity',
-                    $('#ethnicity-as-column__row_order').val(),
+                    $('#ethnicity-as-column__row-order').val(),
                     buildTableColumns(),
                     buildTableColumnNames(),
                     '',

--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -598,8 +598,6 @@ $(document).ready(function () {
         
         $('#complex-table__data-style').val(settings.tableOptions.data_style);
 
-        console.log(settings.tableOptions.selection);
-        console.log(settings.tableOptions.order);
         if (settings.tableOptions.data_style === 'ethnicity_as_row') {
             $('#ethnicity-as-row__columns').val(settings.tableOptions.selection);
             $('#ethnicity-as-row__column-order').val(settings.tableOptions.order);

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -62,8 +62,6 @@
   <body class="{% block body_classes %}{% endblock %}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    {% block body_start %}{% endblock %}
-
     <div id="skiplink-container">
       <div>
         <a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>

--- a/application/templates/cms/create_new_version.html
+++ b/application/templates/cms/create_new_version.html
@@ -4,6 +4,27 @@
 
 {% block body_classes %}rd_cms{% endblock %}
 
+{% block messages %}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+        <div class='grid-row'>
+            <div class='column-full'>
+                <div class="row">
+                    <div class="flash-message">
+                        {% for category, message in messages %}
+                            <div data-alert
+                                 class="alert-box {% if category == 'error' %}alert{% else %}{{ category }}{% endif %}">
+                                <span>{{ message }}</span>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 <main class="main" id="content">
 

--- a/application/templates/static_site/export/_template_export.html
+++ b/application/templates/static_site/export/_template_export.html
@@ -33,8 +33,6 @@
   <body class="{% block body_classes %}{% endblock %}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    {% block body_start %}{% endblock %}
-
     <header id="global-header" class="{% block header_class %}{% endblock %}">
 
     </header>

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,5 @@ display_result $? 1 "Code style check"
 gulp --production
 display_result $? 2 "Frontend asset build check"
 
-py.test -x
+py.test
 display_result $? 3 "Python tests"

--- a/tests/test_static_views.py
+++ b/tests/test_static_views.py
@@ -14,7 +14,6 @@ page_service = PageService()
 def test_rdu_user_can_see_page_if_not_shared(
     test_app_client, db_session, mock_user, stub_topic_page, stub_subtopic_page, stub_measure_page
 ):
-
     assert stub_measure_page.shared_with == []
     assert mock_user.pages == []
 
@@ -39,7 +38,6 @@ def test_rdu_user_can_see_page_if_not_shared(
 def test_departmental_user_cannot_see_page_unless_shared(
     test_app_client, db_session, mock_dept_user, stub_topic_page, stub_subtopic_page, stub_measure_page
 ):
-
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_dept_user.id
 
@@ -86,7 +84,6 @@ def test_departmental_user_cannot_see_page_unless_shared(
 def test_get_file_download_returns_404(
     test_app_client, mock_user, stub_topic_page, stub_subtopic_page, stub_measure_page
 ):
-
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_user.id
 
@@ -107,7 +104,6 @@ def test_get_file_download_returns_404(
 def test_view_export_page(
     test_app_client, db_session, mock_user, stub_topic_page, stub_subtopic_page, stub_measure_page
 ):
-
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_user.id
 
@@ -136,8 +132,8 @@ def test_view_export_page(
 
     assert metadata.find("div", attrs={"id": "department-name"}).text.strip() == "Department for Work and Pensions"
     assert metadata.find("div", attrs={"id": "published-date"}).text.strip() == datetime.now().date().strftime(
-        "%e %B %Y"
-    )  # noqa
+        "%d %B %Y"
+    ).lstrip("0")
     assert metadata.find("div", attrs={"id": "area-covered-value"}).text.strip() == "UK"
     assert metadata.find("div", attrs={"id": "lowest-level-of-geography-value"}).text.strip() == "UK"
     assert metadata.find("div", attrs={"id": "time-period-value"}).text.strip() == "4 months"
@@ -278,7 +274,6 @@ def test_view_topic_page_in_static_mode_does_not_contain_reordering_javascript(
 def test_view_index_page_only_contains_one_topic(
     test_app_client, mock_user, stub_home_page, stub_topic_page, stub_published_measure_page
 ):
-
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_user.id
 
@@ -293,7 +288,6 @@ def test_view_index_page_only_contains_one_topic(
 
 
 def test_view_sandbox_topic(test_app_client, mock_user, stub_sandbox_topic_page):
-
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_user.id
 
@@ -305,7 +299,6 @@ def test_view_sandbox_topic(test_app_client, mock_user, stub_sandbox_topic_page)
 
 
 def test_view_measure_page(test_app_client, mock_user, stub_topic_page, stub_subtopic_page, stub_measure_page):
-
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_user.id
 
@@ -336,7 +329,7 @@ def test_view_measure_page(test_app_client, mock_user, stub_topic_page, stub_sub
     metadata_values = page.find("div", class_="metadata").find_all("dd")
     assert len(metadata_titles) == 5
     assert metadata_values[0].text.strip() == "Department for Work and Pensions"
-    assert metadata_values[1].text.strip() == datetime.now().date().strftime("%d %B %Y")
+    assert metadata_values[1].text.strip() == datetime.now().date().strftime("%d %B %Y").lstrip("0")
     assert metadata_values[2].text.strip() == "DWP Stats"
     assert metadata_values[3].text.strip() == "UK"
     assert metadata_values[4].text.strip() == "4 months"
@@ -539,7 +532,6 @@ def test_topic_page_only_shows_empty_subtopics_if_user_can_create_a_measure(
 def test_measure_page_share_links_do_not_contain_double_slashes_between_domain_and_path(
     test_app_client, db_session, mock_user, stub_topic_page, stub_subtopic_page, stub_measure_page
 ):
-
     assert stub_measure_page.shared_with == []
     assert mock_user.pages == []
 


### PR DESCRIPTION
 ## Summary
We have fields for users to declare which column in their dataset
provides ordering information. We use jQuery to get the value of these
fields, but jQuery silently absorbs errors and returns a null/empty
value, which made us miss the fact that we had the wrong element ID in
the selector. This meant that ordering was never factored into the
table.

 ## Ticket
https://trello.com/c/r0rae1EX/1021 