### PR TITLE
Fix attachment scanner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ AWS_SECRET_ACCESS_KEY=[generate one in AWS]
 
 # You only need to set these if you want to test attachment scanning locally
 ATTACHMENT_SCANNER_API_URL=https://beta.attachmentscanner.com/requests
-ATTACHMENT_SCANNER_API_KEY=[ask someone who knows]
+ATTACHMENT_SCANNER_API_TOKEN=[ask someone who knows]
 
 # You only need to set these if you want your local app to send emails
 MAILGUN_SMTP_SERVER=smtp.mailgun.org

--- a/app.json
+++ b/app.json
@@ -14,6 +14,9 @@
     "ATTACHMENT_SCANNER_URL": {
       "required": true
     },
+    "ATTACHMENT_SCANNER_ENABLED": {
+      "required": true
+    },
     "AWS_ACCESS_KEY_ID": {
       "required": true
     },

--- a/application/cms/exceptions.py
+++ b/application/cms/exceptions.py
@@ -60,21 +60,33 @@ class UpdateAlreadyExists(Exception):
     pass
 
 
-class UploadAlreadyExists(Exception):
+class UploadError(Exception):
     pass
 
 
-class UploadCheckError(Exception):
+class UploadAlreadyExists(UploadError):
     pass
 
 
-class UploadCheckFailed(Exception):
+class UploadCheckError(UploadError):
     pass
 
 
-class UploadCheckPending(Exception):
+class UploadCheckVirusFound(UploadCheckError):
     pass
 
 
-class UploadNotFoundException(Exception):
+class UnknownFileScanStatus(Exception):
+    pass
+
+
+class UploadCheckFailed(UploadError):
+    pass
+
+
+class UploadCheckPending(UploadError):
+    pass
+
+
+class UploadNotFoundException(UploadError):
     pass

--- a/application/cms/scanner_service.py
+++ b/application/cms/scanner_service.py
@@ -1,0 +1,63 @@
+import enum
+import json
+
+import requests
+
+from application.cms.exceptions import (
+    UnknownFileScanStatus,
+    UploadCheckPending,
+    UploadCheckFailed,
+    UploadCheckVirusFound,
+)
+from application.cms.service import Service
+
+
+class ScannerService(Service):
+    class Status(enum.Enum):
+        OK = "ok"
+        PENDING = "pending"
+        FAILED = "failed"
+        FOUND = "found"
+
+    def init_app(self, app):
+        super().init_app(app)
+        self.base_url = self.app.config["ATTACHMENT_SCANNER_URL"]
+        self.token = self.app.config["ATTACHMENT_SCANNER_API_TOKEN"]
+        self.enabled = self.app.config["ATTACHMENT_SCANNER_ENABLED"]
+
+    def scan_file(self, filename, fileobj) -> bool:
+        """
+        return: True if scanned and safe; False if not scanned
+        raises: child of UploadException if scanned and a problem occurred
+        """
+        if self.enabled:
+            response = requests.post(
+                f"{self.base_url}/requests", headers={"Authorization": f"Bearer {self.token}"}, files={"file": fileobj}
+            )
+
+            status = response.json()["status"].lower()
+
+            if status == ScannerService.Status.OK.value:
+                return True
+            elif status == ScannerService.Status.PENDING.value:
+                self.logger.warning(f"Upload scan pending for `{filename}`: check back for result later")
+                raise UploadCheckPending("Upload check did not complete (pending)")
+            elif status == ScannerService.Status.FAILED.value:
+                self.logger.error(f"Upload scan failed for `{filename}`: {response.json()}")
+                raise UploadCheckFailed("Upload check could not be completed (an error occurred)")
+            elif status == ScannerService.Status.FOUND.value:
+                self.logger.error(f"Upload scan detected a virus in `{filename}`: {response.json()}")
+                raise UploadCheckVirusFound("Virus scan has found something suspicious")
+            else:
+                self.logger.warning(f"Unrecognised status from scanning service for `{filename}`: {response.json()}")
+                raise UnknownFileScanStatus(
+                    f"Unrecognised status from scanning service for `{filename}`: {response.json()}"
+                )
+
+        else:
+            self.logger.warning(f"File upload scanning disabled: writing `{filename}` without virus check")
+
+        return False
+
+
+scanner_service = ScannerService()

--- a/application/cms/service.py
+++ b/application/cms/service.py
@@ -6,7 +6,7 @@ from application.utils import setup_module_logging
 
 class Service:
     def __init__(self):
-        self.logger = logging.Logger(inspect.getmodule(self).__name__)
+        self.logger = logging.getLogger(inspect.getmodule(self).__name__)
 
     def init_app(self, app):
         self.logger = setup_module_logging(self.logger, app.config["LOG_LEVEL"])

--- a/application/cms/upload_service.py
+++ b/application/cms/upload_service.py
@@ -1,6 +1,4 @@
-import json
 import os
-import subprocess
 import tempfile
 
 from slugify import slugify
@@ -10,14 +8,15 @@ from werkzeug.utils import secure_filename
 from application import db
 
 from application.cms.exceptions import (
+    PageUnEditable,
     UploadCheckError,
     UploadCheckPending,
-    UploadCheckFailed,
-    PageUnEditable,
+    UploadError,
     UploadNotFoundException,
     UploadAlreadyExists,
 )
 from application.cms.models import Upload
+from application.cms.scanner_service import scanner_service
 from application.cms.service import Service
 from application.utils import create_guid
 
@@ -84,38 +83,23 @@ class UploadService(Service):
         page_file_system = self.app.file_service.page_system(page)
         if not filename:
             filename = file.name
+
         with tempfile.TemporaryDirectory() as tmpdirname:
             tmp_file = "%s/%s" % (tmpdirname, filename)
             file.save(tmp_file)
             self.validate_file(tmp_file)
-            if self.app.config["ATTACHMENT_SCANNER_ENABLED"]:
-                attachment_scanner_url = self.app.config["ATTACHMENT_SCANNER_API_URL"]
-                attachment_scanner_key = self.app.config["ATTACHMENT_SCANNER_API_KEY"]
-                x = subprocess.check_output(
-                    [
-                        "curl",
-                        "--request",
-                        "POST",
-                        "--url",
-                        attachment_scanner_url,
-                        "--header",
-                        "authorization: bearer %s" % attachment_scanner_key,
-                        "--header",
-                        "content-type: multipart/form-data",
-                        "--form",
-                        "file=@%s" % tmp_file,
-                    ]
-                )
-                response = json.loads(x.decode("utf-8"))
-                if response["status"] == "ok":
-                    pass
-                elif response["status"] == "pending":
-                    raise UploadCheckPending("Upload check did not complete, you can check back later, see docs")
-                elif response["status"] == "failed":
-                    raise UploadCheckFailed("Upload check could not be completed, an error occurred.")
-                elif response["status"] == "found":
-                    raise UploadCheckError("Virus scan has found something suspicious.")
+
+            try:
+                scanner_service.scan_file(filename=tmp_file, fileobj=open(tmp_file, "rb"))
+
+            except UploadCheckPending:
+                pass
+
+            except UploadError:
+                raise
+
             page_file_system.write(tmp_file, "source/%s" % secure_filename(filename))
+
         return page_file_system
 
     def delete_upload_obj(self, page, upload):

--- a/application/config.py
+++ b/application/config.py
@@ -66,8 +66,8 @@ class Config:
     DEPLOY_SITE = get_bool(os.environ.get("DEPLOY_SITE", False))
 
     ATTACHMENT_SCANNER_ENABLED = get_bool(os.environ.get("ATTACHMENT_SCANNER_ENABLED", False))
-    ATTACHMENT_SCANNER_API_URL = os.environ.get("ATTACHMENT_SCANNER_API_URL", "")
-    ATTACHMENT_SCANNER_API_KEY = os.environ.get("ATTACHMENT_SCANNER_API_KEY", "")
+    ATTACHMENT_SCANNER_URL = os.environ.get("ATTACHMENT_SCANNER_URL", "")
+    ATTACHMENT_SCANNER_API_TOKEN = os.environ.get("ATTACHMENT_SCANNER_API_TOKEN", "")
 
     JSON_ENABLED = get_bool(os.environ.get("JSON_ENABLED", False))
 
@@ -119,3 +119,5 @@ class TestConfig(DevConfig):
     WTF_CSRF_ENABLED = False
     SESSION_COOKIE_SECURE = False
     ATTACHMENT_SCANNER_ENABLED = False
+    ATTACHMENT_SCANNER_API_TOKEN = "fakeToken"
+    ATTACHMENT_SCANNER_URL = "http://scanner-service"

--- a/application/factory.py
+++ b/application/factory.py
@@ -24,9 +24,10 @@ from application.cms.filters import (
     format_versions,
     format_status,
 )
-from application.cms.page_service import page_service
-from application.cms.upload_service import upload_service
 from application.cms.dimension_service import dimension_service
+from application.cms.page_service import page_service
+from application.cms.scanner_service import scanner_service
+from application.cms.upload_service import upload_service
 from application.dashboard.trello_service import trello_service
 
 from application.static_site.filters import (
@@ -61,6 +62,7 @@ def create_app(config_object):
 
     page_service.init_app(app)
     upload_service.init_app(app)
+    scanner_service.init_app(app)
     dimension_service.init_app(app)
 
     trello_service.init_app(app)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,6 +11,8 @@ pytest==3.4.0
 pytest-cov==2.5.1
 pytest-flask==0.10.0
 pytest-mock==1.10.0
+requests-mock==1.5.2
 selenium==3.8.0
+testfixtures==6.2.0
 text-unidecode==1.2   # Required by Faker
 black==18.6b4

--- a/tests/test_scanner_service.py
+++ b/tests/test_scanner_service.py
@@ -1,0 +1,84 @@
+from contextlib import suppress
+from tempfile import TemporaryFile
+
+import pytest
+from testfixtures import LogCapture
+
+from application.cms.exceptions import (
+    UploadCheckPending,
+    UploadCheckFailed,
+    UploadCheckVirusFound,
+    UnknownFileScanStatus,
+)
+from tests.utils import UnmockedRequestException
+
+
+def test_file_is_posted_to_remote_api(scanner_service, requests_mocker):
+    # Check that we're definitely making _a_ request by hitting the global unmocked request exception
+    with pytest.raises(UnmockedRequestException):
+        with TemporaryFile() as tmpfile:
+            scanner_service.scan_file(filename="test", fileobj=tmpfile)
+
+    requests_mocker.post("http://scanner-service/requests", json={"status": "ok"})
+
+    # Check that we no longer get an exception after mocking the intended target endpoint
+    with TemporaryFile() as tmpfile:
+        scanner_service.scan_file(filename="test", fileobj=tmpfile)
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_scanner_service_respects_config_enabled(enabled, scanner_service, requests_mocker):
+    scanner_service.enabled = enabled
+
+    if enabled:
+        requests_mocker.post("http://scanner-service/requests", json={"status": "ok"})
+
+    with TemporaryFile() as tmpfile:
+        assert scanner_service.scan_file(filename="test", fileobj=tmpfile) is enabled
+
+
+@pytest.mark.parametrize(
+    "status, expected_exception",
+    (
+        ("ok", None),
+        ("pending", UploadCheckPending),
+        ("failed", UploadCheckFailed),
+        ("found", UploadCheckVirusFound),
+        ("unknown", UnknownFileScanStatus),
+    ),
+)
+def test_exception_raised_for_scan_results(status, expected_exception, scanner_service, requests_mocker):
+    requests_mocker.post("http://scanner-service/requests", json={"status": status})
+
+    context_manager = pytest.raises(expected_exception) if expected_exception else suppress()
+    with context_manager:
+        with TemporaryFile() as tmpfile:
+            scanner_service.scan_file(filename="test", fileobj=tmpfile)
+
+
+@pytest.mark.parametrize(
+    "enabled, status, expected_log_message",
+    (
+        (False, "ok", "File upload scanning disabled: writing `test` without virus check"),
+        (True, "ok", None),
+        (True, "pending", "Upload scan pending for `test`: check back for result later"),
+        (True, "failed", "Upload scan failed for `test`: {'status': 'failed'}"),
+        (True, "found", "Upload scan detected a virus in `test`: {'status': 'found'}"),
+        (True, "unknown", "Unrecognised status from scanning service for `test`: {'status': 'unknown'}"),
+    ),
+)
+def test_scanner_service_logging(enabled, status, expected_log_message, scanner_service, requests_mocker):
+    scanner_service.enabled = enabled
+
+    requests_mocker.post("http://scanner-service/requests", json={"status": status})
+
+    with LogCapture("application.cms.scanner_service") as log_catcher:
+        with TemporaryFile() as tmpfile:
+            try:
+                scanner_service.scan_file(filename="test", fileobj=tmpfile)
+            except Exception:
+                pass
+
+        if expected_log_message:
+            assert len(log_catcher.records) == 1
+            assert log_catcher.records[0].message == expected_log_message

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,2 @@
+class UnmockedRequestException(Exception):
+    pass


### PR DESCRIPTION
 ## Summary
We had code to make use of an integration from Heroku for scanning
uploaded documents, but a number of bugs in the implementation meant
this wouldn't ever work (although we also didn't have the correct
environment variable set on our instances to turn the functionality on -
ATTACHMENT_SCANNER_ENABLED).

This patch fixes up the scanning code, separates it our into a distinct
scanning service, and adds tests around the functionality. Once this has
shipped out, we need to enable the feature through the environment
variable above.

It also creates a parent exception for upload errors (UploadError) and
moves the existing upload errors into subclasses of that parent.

One noteworthy decision made in this: if our file scanner reports
that the file scan is 'pending', we will still let it be uploaded. We'll
emit a warning to the logger, so we could have sentry/papertrail alert
us to this case, but the alternative is to block the upload altogether.
I'm not sure how often scans will come back as pending, so I opted to be
permissive here. Maybe we shouldn't be?

Given that the attachment scanner calls out to an external service, I've
also mocked out the requests library across our entire test suite. Any
requests made will now raise `UnmockedRequestException` unless the
specific URL/response is mocked out subsequently. This should give us a
good level of confidence that our tests aren't sending fake/crap data
out to our providers.

We don't seem to have any direct unit tests for our `UploadService`
class, but that's too big a beast to handle as part of this ticket so
I'll be making a separate story for it on our tech debt board. I wanted
to at least do an integration test between the UploadService and the
ScannerService, but that proved a bit painful as the method also uses
a FileService that is set up differently and didn't seem easy to mock
out. We'll have to tackle this later.

We also didn't have an attachment scanner on our staging instance;
I've added one to it now.

 ## Ticket
https://trello.com/c/nT2ysJkS/963