### PR TITLE
Edit and preview fixes

### DIFF
--- a/application/src/js/cms_autosave/click_to_edit.js
+++ b/application/src/js/cms_autosave/click_to_edit.js
@@ -39,7 +39,7 @@
         function inputBlurred(event) {
 
             if (!edit.classList.contains('hidden') && !event.target.classList.contains('js-dependent')) {
-                saveAndPreview();
+                saveAndPreview(event);
             }
         }
 
@@ -95,6 +95,7 @@
             }
 
             showPreview();
+            event.preventDefault()
         }
 
         function previewKeyedUp(event) {

--- a/application/src/js/cms_autosave/click_to_edit.js
+++ b/application/src/js/cms_autosave/click_to_edit.js
@@ -27,7 +27,6 @@
 
             var cancel = edit.querySelector('.cancel')
             if (cancel) {
-                cancel.addEventListener('mousedown', cancelMousedDown);
                 cancel.addEventListener('click', cancelClicked);
             }
 
@@ -44,11 +43,6 @@
             }
         }
 
-        function cancelMousedDown(event) {
-            // Prevent the blur event firing.
-            event.preventDefault();
-        }
-
         function cancelClicked(event) {
 
             showPreview();
@@ -60,6 +54,8 @@
                     text_inputs[0].value = preview.textContent;
                 }
             }
+
+            event.preventDefault()
         }
 
         function enterKeyPressed(event) {

--- a/application/src/js/cms_autosave/click_to_edit.js
+++ b/application/src/js/cms_autosave/click_to_edit.js
@@ -38,7 +38,7 @@
 
         function inputBlurred(event) {
 
-            if (!edit.classList.contains('hidden')) {
+            if (!edit.classList.contains('hidden') && !event.target.classList.contains('js-dependent')) {
                 saveAndPreview();
             }
         }

--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -835,10 +835,6 @@ table.ethnicity-categorisations th.numeric {
       color: #B10E1E;
     }
 
-    button.link.save {
-      display: none;
-    }
-
     input {
         &:focus {
             outline: 3px solid $focus-colour;

--- a/application/templates/cms_autosave/_measure_title.html
+++ b/application/templates/cms_autosave/_measure_title.html
@@ -1,6 +1,6 @@
 {% from "cms_autosave/macros.html" import editable_heading %}
 <div class="grid-row">
-    <div class="column-full">
+    <div class="column-two-thirds">
         {{ editable_heading(measure.title, field_name="title", empty_message="Click to add Title", tab_index=0) }}
     </div>
 </div>

--- a/application/templates/cms_autosave/_methodology.html
+++ b/application/templates/cms_autosave/_methodology.html
@@ -17,9 +17,6 @@
         <h3 class="heading-small">Related publications</h3>
         {{ editable_textarea(measure.related_publications, field_name="related_publications", empty_message="Click to add", tab_index=11) }}
 
-        {# Published measure page doesn't have a heading; TODO: Decide if we want one here
-           <h3 class="heading-small">Quality and methodology information</h3>
-        #}
         {{ editable_link(link_text='Quality and methodology information', link_url=measure.qmi_url, link_text_field_name=None, link_url_field_name='qmi_url', empty_message="Click to add", tab_index=12) }}
 
         <h3 class="heading-small">Further technical information</h3>

--- a/application/templates/cms_autosave/edit_and_preview_measure.html
+++ b/application/templates/cms_autosave/edit_and_preview_measure.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "cms/base.html" %}
 
 {% block endhead %}
     <script>
@@ -14,31 +14,33 @@
 {% block messages %}{% include 'cms_autosave/_messages.html' %}{% endblock %}
 
 {% block main_content %}
-<form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
-    <div class="rd_cms_autocomplete">
-        {% include 'cms_autosave/_measure_title.html' %}
-        {% include 'cms_autosave/_public_metadata.html' %}
-        {% include 'cms_autosave/_main_commentary.html' %}
-        {% include 'cms_autosave/_dimensions.html' %}
+<main id="content" class="main">
+    <form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+        <div class="rd_cms_autocomplete">
+            {% include 'cms_autosave/_measure_title.html' %}
+            {% include 'cms_autosave/_public_metadata.html' %}
+            {% include 'cms_autosave/_main_commentary.html' %}
+            {% include 'cms_autosave/_dimensions.html' %}
 
-            <div class="grid-row">
-            <div class="column-two-thirds">
-                <div class="accordion">
-                {% include 'cms_autosave/_methodology.html' %}
-                {% include 'cms_autosave/_data_sources.html' %}
-                {% include 'cms_autosave/_downloads.html' %}
+                <div class="grid-row">
+                <div class="column-two-thirds">
+                    <div class="accordion">
+                    {% include 'cms_autosave/_methodology.html' %}
+                    {% include 'cms_autosave/_data_sources.html' %}
+                    {% include 'cms_autosave/_downloads.html' %}
+                    </div>
                 </div>
             </div>
-        </div>
-    {% if not new %}{{ form.db_version_id }}{% endif %}
-    {% if measure.status == 'DRAFT' or new %}
-        <div class="grid-row">
-            <div class="column-two-thirds">
-            {{ form.csrf_token }}
-            <button class="button" type="submit" name="save">Save</button>
+        {% if not new %}{{ form.db_version_id }}{% endif %}
+        {% if measure.status == 'DRAFT' or new %}
+            <div class="grid-row">
+                <div class="column-two-thirds">
+                {{ form.csrf_token }}
+                <button class="button" type="submit" name="save">Save</button>
+                </div>
             </div>
+        {% endif %}
         </div>
-    {% endif %}
-    </div>
-</form>
+    </form>
+</main>
 {% endblock %}

--- a/application/templates/cms_autosave/edit_and_preview_measure.html
+++ b/application/templates/cms_autosave/edit_and_preview_measure.html
@@ -1,6 +1,6 @@
 {% extends "cms/base.html" %}
 
-{% block endhead %}
+{% block scripts %}
     <script>
         var set_dimension_order_post_url = "{{ url_for('cms.set_dimension_order', topic=topic.guid,
                                                             subtopic=subtopic.guid,

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -76,7 +76,6 @@
         <div class="edit hidden">
             <textarea name="{{ kwargs['field_name'] }}" rows="10" cols="50" class="for-bullets">{% if value %}{{ value }}{% endif %}</textarea>
             <div>
-                <button class="link save">Save</button>
                 <button class="link cancel">Cancel</button>
             </div>
         </div>
@@ -93,7 +92,7 @@
             <div class="preview-and-edit">
               <div class="preview {% if not value %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
               {% if value -%}
-                  {{ value }}
+                  {{ value | render_markdown }}
               {% else %}
                   {{ kwargs['empty_message'] }}
               {%- endif %}
@@ -101,7 +100,6 @@
             <div class="edit hidden">
                 <textarea name="{{ kwargs['field_name'] }}" rows="5" cols="50" class="for-bullets">{% if value %}{{ value }}{% endif %}</textarea>
                 <div>
-                    <button class="link save">Save</button>
                     <button class="link cancel">Cancel</button>
                 </div>
             </div>
@@ -124,7 +122,6 @@
         </p>
       <div class="edit hidden">
           <input type="text" name="{{ kwargs['field_name'] }}" />
-          <button class="link save">Save</button>
           <button class="link cancel">Cancel</button>
       </div>
     </div>
@@ -145,7 +142,6 @@
         <div class="edit hidden">
             <textarea name="{{ kwargs['field_name'] }}" rows="5" cols="50">{% if value %}{{ value }}{% endif %}</textarea>
             <div>
-                <button class="link save">Save</button>
                 <button class="link cancel">Cancel</button>
             </div>
         </div>
@@ -195,24 +191,26 @@
 {% macro editable_link(link_text, link_url, link_text_field_name, link_url_field_name) -%}
 
     <div class="preview-and-edit">
-        <p class="empty preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-            <span class="pretend-link">
-                {% if link_text -%}
-                    {{ link_text }}
-                {% else %}
-                    {{ kwargs['empty_message'] }}
-                {%- endif %}
-            </span>
-        </p>
-        <div class="edit hidden">
-            {% if link_text_field_name -%}
-            Link text <input type="text" name="{{ link_text_field_name }}" value="{{ link_text if link_text else '' }}" />
-            {% elif link_text -%}
+        <p class="{{ 'empty' if not link_text }} preview pretend-link" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+            {% if link_text -%}
                 {{ link_text }}
             {% else %}
                 {{ kwargs['empty_message'] }}
             {%- endif %}
-            URL <input type="url" name="{{ link_url_field_name }}" value="{{ link_url if link_url else '' }}" />
+        </p>
+        <div class="edit hidden">
+            <div>
+                {% if link_text_field_name -%}
+                Link text <input type="text" name="{{ link_text_field_name }}" value="{{ link_text if link_text else '' }}" class="js-dependent" />
+                {% elif link_text -%}
+                    {{ link_text }}
+                {% else %}
+                    {{ kwargs['empty_message'] }}
+                {%- endif %}
+            </div>
+            <div>
+                URL <input type="url" name="{{ link_url_field_name }}" value="{{ link_url if link_url else '' }}" class="js-dependent" />
+            </div>
             <div>
                 <button class="link save">Save</button>
                 <button class="link cancel">Cancel</button>
@@ -286,7 +284,6 @@
                                         measure.department_source_id if measure else None,
                                         organisations_by_type) }}
             <div>
-                <button class="link save">Save</button>
                 <button class="link cancel">Cancel</button>
             </div>
         </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -66,15 +66,13 @@
 {% macro editable_textarea_for_bullets(value) -%}
 
     <div class="preview-and-edit">
-        <ul class="bullets spaced-out preview {% if not value %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-            <li>
+        <div class="bullets spaced-out preview {% if not value %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
             {% if value -%}
-                {{ value }}
+                {{ value | render_markdown }}
             {% else %}
                 {{ kwargs['empty_message'] }}
             {%- endif %}
-            </li>
-        </ul>
+        </div>
         <div class="edit hidden">
             <textarea name="{{ kwargs['field_name'] }}" rows="10" cols="50" class="for-bullets">{% if value %}{{ value }}{% endif %}</textarea>
             <div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -132,15 +132,15 @@
 {% macro editable_textarea(value) -%}
 
     <div class="preview-and-edit">
-        <p class="{{ 'empty' if not value }} preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+        <div class="{{ 'empty' if not value }} preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
         {% if value -%}
             {{ value | render_markdown }}
         {% else %}
             {{ kwargs['empty_message'] }}
         {%- endif %}
-        </p>
+        </div>
         <div class="edit hidden">
-            <textarea name="{{ kwargs['field_name'] }}" rows="5" cols="50">{% if value %}{{ value }}{% endif %}</textarea>
+            <textarea name="{{ kwargs['field_name'] }}" rows="5" cols="50" class="for-paragraphs">{% if value %}{{ value }}{% endif %}</textarea>
             <div>
                 <button class="link cancel">Cancel</button>
             </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -135,9 +135,9 @@
 {% macro editable_textarea(value) -%}
 
     <div class="preview-and-edit">
-        <p class="empty preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+        <p class="{{ 'empty' if not value }} preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
         {% if value -%}
-            {{ value }}
+            {{ value | render_markdown }}
         {% else %}
             {{ kwargs['empty_message'] }}
         {%- endif %}
@@ -249,7 +249,7 @@
             {% if other_field %}
                 <div class="panel panel-border-narrow form-group" id="{{ kwargs['field_name'] }}-other-field">
                   {{ other_field.label(class="form-label") }}
-                  {{ other_field() }}
+                  {{ other_field(class="js-dependent") }}
                 </div>
 
                 <script>


### PR DESCRIPTION
This fixes these issues:

* Bullets (eg "Main facts and figures") are not rendered when the page first loads - only after edit box has been clicked in and out of.
* Data source URL boxes - can only edit text, but element closes again when you try to edit the URL.
* Data source Publication Frequency radios - once "Other" is selected and focus moves to the "Other" text box then you can't ever click back to any of the radio button values without the elemet closing.
* Quality and Methodology URL box doesn't close once opened for editing
* Editable URL fields seem to lose the "pretend-link" styling after editing
* Some values are displayed in grey and some (eg type of data) are black - why? Need to fix styling.