### PR TITLE
Add post-commit hook to clean index

### DIFF
--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -2,4 +2,5 @@
 
 # Symbolic links to git hooks need to be installed relative to the hooks directory to be resolved.
 (cd .git/hooks; ln -sf ../../scripts/pre-commit pre-commit)
+(cd .git/hooks; ln -sf ../../scripts/post-commit post-commit)
 echo "RD_CMS hooks installed."

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -1,0 +1,1 @@
+git update-index -g


### PR DESCRIPTION
## Summary
Adds a post-commit hook that flushes the git index so that, after committing through PyCharm's GUI, the git CLI doesn't report changes to files which were re-formatted by Black.

This is mostly due to PyCharm using the `--only` argument to `git commit`, which bypasses the staging area. See details here: https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000119350-Local-history-reports-files-changed-by-git-pre-commit-hook

This means that seamless integration with `black` formatting (automatically applied on commit) can be enabled by running `scripts/install_hooks.sh` from the `rd_cms` repository root.