### PR TITLE
 Change error message on uploading bad file

### DIFF
--- a/application/cms/upload_service.py
+++ b/application/cms/upload_service.py
@@ -51,15 +51,19 @@ class UploadService(Service):
                     break
             detector.close()
             encoding = detector.result.get("encoding")
-        valid_encodings = ["ascii", "iso-8859-1", "utf-8"]
+        valid_encodings = ["ASCII", "ISO-8859-1", "UTF-8"]
+
         if encoding is None:
-            message = "File encoding could not be detected"
+            message = "Please check that you are uploading a CSV file."
             self.logger.exception(message)
             raise UploadCheckError(message)
-        if encoding.lower() not in valid_encodings:
-            message = "File encoding %s not valid. Valid encodings: %s" % (encoding, valid_encodings)
+
+        if encoding.upper() not in valid_encodings:
+            message = "File encoding %s not valid. Valid encodings: %s" % (encoding, ", ".join(valid_encodings))
             self.logger.exception(message)
             raise UploadCheckError(message)
+
+        return encoding.upper()
 
     def delete_upload_files(self, page, file_name):
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from application.auth.models import *
 from application.cms.data_utils import Harmoniser
 from application.cms.models import *
 from application.cms.scanner_service import ScannerService
+from application.cms.upload_service import UploadService
 from application.config import TestConfig
 from application.factory import create_app
 from tests.test_data.chart_and_table import simple_table, grouped_table, single_series_bar_chart, multi_series_bar_chart
@@ -703,3 +704,11 @@ def scanner_service(app):
 @pytest.fixture(scope="function")
 def scanner_service_mock(mocker):
     return mocker.patch("application.cms.scanner_service.scanner_service")
+
+
+@pytest.fixture(scope="function")
+def upload_service(app):
+    upload_service = UploadService()
+    upload_service.init_app(app)
+    upload_service.enabled = True
+    return upload_service

--- a/tests/test_upload_service.py
+++ b/tests/test_upload_service.py
@@ -1,0 +1,53 @@
+from contextlib import suppress
+import os
+from tempfile import NamedTemporaryFile
+
+import pytest
+from testfixtures import LogCapture
+
+from application.cms.exceptions import UploadCheckError
+
+
+class TestUploadService:
+    def setup(self):
+        self.temp_file = NamedTemporaryFile(mode="wb", delete=False)
+
+    def teardown(self):
+        try:
+            os.unlink(self.temp_file.name)
+
+        except OSError:
+            pass
+
+    @pytest.mark.parametrize(
+        "contents, expected_encoding",
+        (
+            (b"ascii", "ASCII"),
+            (b"\xa5 \xa9 \xb5 \xbc", "ISO-8859-1"),  # "¥ © µ ¼" in ISO-8859-1 (latin1) encoding
+            (b"\xc2\xa5 \xc2\xa9 \xc2\xb5 \xc2\xbc", "UTF-8"),  # "¥ © µ ¼" in UTF-8 encoding
+        ),
+    )
+    def test_validate_file(self, app, upload_service, contents, expected_encoding):
+        with self.temp_file as tempfile:
+            tempfile.write(contents)
+
+        assert upload_service.validate_file(tempfile.name) == expected_encoding
+
+    @pytest.mark.parametrize(
+        "contents, expected_error_message",
+        (
+            (b"", "Please check that you are uploading a CSV file."),
+            (
+                b"\xff\xfe\x00\x00\xa5\x00\x00\x00",  # "¥" in UTF-32 encoding
+                "File encoding UTF-32 not valid. Valid encodings: ASCII, ISO-8859-1, UTF-8",
+            ),
+        ),
+    )
+    def test_file_with_invalid_encoding(self, app, upload_service, contents, expected_error_message):
+        with self.temp_file as tempfile:
+            tempfile.write(contents)
+
+        with pytest.raises(UploadCheckError) as e:
+            upload_service.validate_file(tempfile.name)
+
+        assert e.match(expected_error_message)


### PR DESCRIPTION
 ## Summary
**Note**: This PR sits on top of the #747; please only review final
commit.

If a user uploads a file and we can't detect any encodings for that
file, we send back a vague error message about not being able to detect
an encoding. It's more helpful for the user to tell them that they ought
to be uploading a CSV file. We have a separate error message already
available if they upload a CSV/text file that has an unsupported
encoding.

Also adds a couple of tests around the `validate_file` method of the
`UploadService` - note that the rest of the class is untested. We have a
tech improvement ticket for addressing this at a later date.

 ## Ticket
https://trello.com/c/MjyJbEWG/668