### PR TITLE
Add latest measure title as page context

### DIFF
--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -1002,7 +1002,7 @@ def list_measure_page_versions(topic, subtopic, measure):
     measures.sort(reverse=True)
     if not measures:
         return redirect(url_for("cms.subtopic", topic=topic, subtopic=subtopic))
-    measure_title = measures[0].title if measures else ""
+    measure_title = next(measure for measure in measures if measure.latest).title
     return render_template(
         "cms/measure_page_versions.html",
         topic=topic_page,

--- a/application/templates/cms/measure_page_versions.html
+++ b/application/templates/cms/measure_page_versions.html
@@ -3,7 +3,8 @@
 {% from "cms/measure_actions.html" import render_actions with context %}
 
 {% block body_classes %}rd_cms{% endblock %}
-{% block page_title %}Measure page versions{% endblock %}
+{% block page_title %}Version history: {{ measure_title }}{% endblock %}
+
 
 {% block messages %}
   <div class='grid-row'>
@@ -39,7 +40,13 @@
 
     <div class='grid-row'>
         <div class="column-two-thirds">
-            <h1 class='heading-large'>Version history</h1>
+            <h1 class='heading-large'>
+              Version history
+              <span class="heading-secondary">
+                <span class="visually-hidden">of </span>
+                {{ measure_title }}
+              </span>
+            </h1>
         </div>
     </div>
     <div class='grid-row'>


### PR DESCRIPTION
 ## Summary
When looking at all versions of a measure, the page doesn't show the
name of the measure anywhere, making it easy to lose context if you stop
paying attention or get distracted briefly.

This adds the name of the most recent version of the measure to the page
title as a secondary/context heading, including text to make it read
nicely for screen readers.

 ## Ticket
https://trello.com/c/cOUCruoT/778