### PR TITLE
Be really sure we have an error code to render

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -241,8 +241,8 @@ def register_errorhandlers(app):
     app.errorhandler(PageNotFoundException)(what_you_asked_for_is_not_there_handler)
 
     def render_error(error):
-        # If a HTTPException, pull the `code` attribute; default to 500
-        error_code = getattr(error, "code", 500)
+        # Try to get the `code` attribute (which will exist for HTTPExceptions); use 500 if no code found
+        error_code = getattr(error, "code", None) or 500
 
         if re.match(r"/cms", request.path):
             return render_template("error/{0}.html".format(error_code)), error_code


### PR DESCRIPTION
We have recently seen an error in production where the render_error
method was attempting to render the template `None.html`.

So it looks like the underlying error did have an attribute "code" but
it's value was None, so the default 500 was not being set.

The change here should ensure that we hit the 500.html template for any
future errors that come through with `code = None`.