### PR TITLE
Use https for nationalarchives footer link

### DIFF
--- a/application/templates/_shared/_footer.html
+++ b/application/templates/_shared/_footer.html
@@ -49,7 +49,7 @@
       </div>
 
       <div class="copyright">
-        <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">{{ crown_copyright_message|default('&copy; Crown copyright')|safe }}</a>
+        <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">{{ crown_copyright_message|default('&copy; Crown copyright')|safe }}</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The style guide has https link for this, and other links to the same
site are https in our footer.  Feels like this should also be https here.