### PR TITLE
Upgrade Flask to 0.12.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cffi==1.11.4
 chardet==3.0.4
 click==6.7
 docutils==0.14
-Flask==0.12.2
+Flask==0.12.4
 Flask-BabelEx==0.9.3
 Flask-Login==0.4.1
 Flask-Mail==0.9.1


### PR DESCRIPTION
Github has been reporting a vulnerable dependency but not shown what it
actually is.  I had a dig round using "safety" which pointed to Flask
being the culprit.

I tried going all the way to Flask 1.0.2 but there are issues getting
the Selenium tests to be happy that I'm not going to dig too far into
right now.

This halfway update will patch the security vulnerability, and we can
spend the time to upgrade to 1.0.2 at our leisure.