### PR TITLE
Fix pushing site to Github and upload .map files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ root of the project containing the values below. This file should not be committ
 and therefore any variables needed for the application need to be set manually on Heroku.
 ```
 ACCOUNT_WHITELIST="['your email address if it is not a gov.uk one']"
-ENVIRONMENT=LOCAL_DEV
+ENVIRONMENT=DEVELOPMENT
 DATABASE_URL=postgresql://postgres@localhost:5432/rdcms
 TEST_DATABASE_URL=postgresql://postgres@localhost:5432/rdcms_test
 PGSSLMODE=allow

--- a/application/cms/file_service.py
+++ b/application/cms/file_service.py
@@ -111,13 +111,17 @@ class S3FileSystem:
 
         with open(file=local_path, mode="rb") as file:
             mimetype = mimetypes.guess_type(local_path, strict=False)[0]
+            if mimetype is None and local_path.endswith(".map"):
+                # .map files are sourcemaps which tell browsers how minified CSS and JS relates back to source files
+                # setting mimetype to "application/json" is recommended and makes the files viewable in browsers
+                mimetype = "application/json"
             if mimetype:
                 self.bucket.upload_fileobj(
                     Key=fs_path,
                     Fileobj=file,
                     ExtraArgs={"ContentType": mimetype, "CacheControl": "max-age=%s" % max_age_seconds},
                 )
-            if mimetype is None:
+            else:
                 if strict:
                     raise UploadCheckError("Couldn't determine the type of file you uploaded")
                 else:

--- a/application/config.py
+++ b/application/config.py
@@ -113,7 +113,7 @@ class Config:
 class DevConfig(Config):
     DEBUG = True
     LOG_LEVEL = logging.DEBUG
-    ENVIRONMENT = "DEV"
+    ENVIRONMENT = "DEVELOPMENT"
     SESSION_COOKIE_SECURE = False
     SERVER_NAME = "localhost:5000"
 

--- a/application/config.py
+++ b/application/config.py
@@ -113,7 +113,6 @@ class Config:
 class DevConfig(Config):
     DEBUG = True
     LOG_LEVEL = logging.DEBUG
-    PUSH_SITE = False
     FETCH_ENABLED = False
     ENVIRONMENT = "DEV"
     SESSION_COOKIE_SECURE = False

--- a/application/config.py
+++ b/application/config.py
@@ -20,7 +20,7 @@ load_dotenv(dotenv_path)
 class Config:
     DEBUG = False
     LOG_LEVEL = logging.INFO
-    ENVIRONMENT = os.environ.get("ENVIRONMENT", "PROD")
+    ENVIRONMENT = os.environ.get("ENVIRONMENT", "PRODUCTION")
     SECRET_KEY = os.environ["SECRET_KEY"]
     PROJECT_NAME = "rd_cms"
     BASE_DIRECTORY = dirname(dirname(os.path.abspath(__file__)))
@@ -113,7 +113,6 @@ class Config:
 class DevConfig(Config):
     DEBUG = True
     LOG_LEVEL = logging.DEBUG
-    FETCH_ENABLED = False
     ENVIRONMENT = "DEV"
     SESSION_COOKIE_SECURE = False
     SERVER_NAME = "localhost:5000"

--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 
-from flask import current_app, render_template, url_for
+from flask import current_app, render_template
 from git import Repo
 from slugify import slugify
 
@@ -18,7 +18,6 @@ from application.cms.api_builder import build_measure_json, build_index_json
 
 def do_it(application, build):
     with application.app_context():
-
         base_build_dir = application.config["STATIC_BUILD_DIR"]
         os.makedirs(base_build_dir, exist_ok=True)
         build_timestamp = build.created_at.strftime("%Y%m%d_%H%M%S.%f")
@@ -48,15 +47,16 @@ def do_it(application, build):
 
         build_other_static_pages(build_dir)
 
-        print("Push site to git ", application.config["PUSH_SITE"])
+        print(f"{'Pushing' if application.config['PUSH_SITE'] else 'NOT pushing'} site to git")
         if application.config["PUSH_SITE"]:
             push_site(build_dir, build_timestamp)
 
-        print("Deploy site to S3 ", application.config["DEPLOY_SITE"])
+        print(f"{'Deploying' if application.config['DEPLOY_SITE'] else 'NOT deploying'} site to S3")
         if application.config["DEPLOY_SITE"]:
             from application.sitebuilder.build_service import s3_deployer
 
             s3_deployer(application, build_dir, deletions=pages_unpublished)
+            print("Static site deployed")
 
         if not local_build:
             clear_up(build_dir)
@@ -205,7 +205,7 @@ def process_dimensions(page, uri):
             with open(file_path, "w") as dimension_file:
                 dimension_file.write(output)
         except Exception as e:
-            print("Could not write file path", file_path)
+            print(f"Could not write file path {file_path}")
             print(e)
 
         d_as_dict = d.to_dict()
@@ -398,7 +398,7 @@ def push_site(build_dir, build_timestamp):
     message = "Static site pushed with build timestamp %s" % build_timestamp
     repo.index.commit(message)
     repo.remotes.origin.push()
-    print("static site pushed")
+    print(message)
 
 
 def clear_up(build_dir):

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,7 @@ from application.redirects.models import *
 from application.sitebuilder.models import *
 from application.utils import create_and_send_activation_email, send_email
 
-if os.environ.get("ENVIRONMENT", "DEV").lower().startswith("dev"):
+if os.environ.get("ENVIRONMENT", "DEVELOPMENT").lower().startswith("dev"):
     app = create_app(DevConfig)
 else:
     app = create_app(Config)

--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,6 @@
 import sys
 
 import os
-import uuid
 from flask_migrate import Migrate, MigrateCommand
 from flask_script import Manager, Server
 from flask_security import SQLAlchemyUserDatastore
@@ -13,18 +12,16 @@ from application.auth.models import *
 from application.cms.categorisation_service import categorisation_service
 from application.cms.exceptions import CategorisationNotFoundException
 from application.cms.models import *
-from application.config import DevConfig
+from application.config import Config, DevConfig
 from application.factory import create_app
 from application.redirects.models import *
 from application.sitebuilder.models import *
 from application.utils import create_and_send_activation_email, send_email
 
-env = os.environ.get("ENVIRONMENT", "DEV")
-# if env.lower() == 'dev':
-#     app = create_app(DevConfig)
-# else:
-#     app = create_app(Config)
-app = create_app(DevConfig)
+if os.environ.get("ENVIRONMENT", "DEV").lower().startswith("dev"):
+    app = create_app(DevConfig)
+else:
+    app = create_app(Config)
 
 manager = Manager(app)
 manager.add_command("server", Server())
@@ -127,8 +124,8 @@ def force_build_static_site():
         from application.sitebuilder.build_service import build_site
 
         request_build()
-        build_site(app)
         print("An immediate build has been requested")
+        build_site(app)
     else:
         print("Build is disabled at the moment. Set BUILD_SITE to true to enable")
 


### PR DESCRIPTION
I noticed that our static builds haven't been pushing to rd_html since 29th August and tracked the issue down to this commit: https://github.com/racedisparityaudit/rd_cms/commit/fbaae003dd544a26edeae33602e7718ad1a4e9e8
which (wrongly) changed the **DEV** config to have `PUSH_SITE=False`.

I've removed that line from the config, so that the value of PUSH_SITE set in the environment will be used.

But the question remained why a change to DEV config would affect our PRODUCTION builds.  It turns out that for the last year all management commands have been run using DevConfig, no matter what environment they are running in.  So I've also changed it so that builds running in PROD use PROD config.  The only differences seem to be the logging level (which makes no difference to build and management commands because they tend to `print` rather than `logger.xxx`) and the `SESSION_COOKIE_SECURE` value, which is False in dev but True in prod.  I have run a static site build locally with this set to True and it builds fine, so I think this change shouldn't break things.

While I was here I also added the `.map` files to our S3 deploy, as per this ticket: https://trello.com/c/fYwldlEo/940-fix-build-process-so-that-map-files-are-deployed
