### PR TITLE
Bugfix: Divide by Zero error

### DIFF
--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -426,9 +426,23 @@ $(document).ready(function () {
         return columns
     }
 
+    // This function examines the HTML page and returns an array of headings for columns
+    // being used.
+    //
+    // Note that a column may have no header, and that this is represented by a empty string,
+    // eg ['']. This is important as the length of this array is also used to determine the
+    // number of columns in use.
     function buildTableColumnNames() {
         var columns = []
-        $('.column_option_picker_name').each(function (idx) { if ($(this).val() !== '') { columns.push($(this).val()); }; });
+
+        $('.column_option_picker').each(function(index) {
+
+            if($(this).val() !== 'none') {
+                columns.push($('.column_option_picker_name')[index].value)
+            }
+
+        })
+
         return columns
     }
 


### PR DESCRIPTION
This fixes a bug causing a 500 error (from a `ZeroDivisionError`), which can be repeated as follows:

1. Edit a table containing 'complex' data (more than one value per ethnicity)
2. Select "Use ethnicity for columns"
3. Select a value in the Column 1 dropdown, but leave all the other Column dropdowns set to [None]
4. Edit the heading in the text beneath the Column 1 dropdown to make it blank
5. Save the Table
6. Preview the page

The bug is caused by having an empty array (`[]`) for the `columns` property in the table JSON object (which represents the column headings) rather than an array containing an empty string `([""]`).