### PR TITLE
Avoid 500 error if user has been removed before activating account

### DIFF
--- a/application/register/views.py
+++ b/application/register/views.py
@@ -24,6 +24,9 @@ def confirm_account(token):
     form = SetPasswordForm()
     user = User.query.filter_by(email=email).first()
 
+    if not user:
+        abort(404)
+
     if user.active:
         flash("Account already confirmed and password set")
         return redirect(url_for("register.completed", user_email=user.email))


### PR DESCRIPTION
If a user is removed before they click the link in their email but while
the token is still valid then currently there will be an error (such as we've just seen: https://sentry.io/rd-cms/ethnicity-facts-figures/issues/686457909/).  
We should instead just 404 if the user has been removed.

We have also seen a second error in `#prod_issues` that I was planning to address at the same time as this one (https://sentry.io/rd-cms/ethnicity-facts-figures/issues/686514130), but the problematic code seems to have been refactored away in master branch.  So I've released the refactored code to production and let's see if a similar error happens again.
