### PR TITLE
Use new Heroku-18 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,5 @@
 {
+  "stack": "heroku-18",
   "name": "rd_cms",
   "description": "",
   "scripts": {


### PR DESCRIPTION
Our Selenium tests have been failing since the Heroku-18 stack became
default.

Rather than fight it, we should be able to upgrade to the new stack
to make things work again.