### PR TITLE
This fixes the saving of the in-page-edit

### DIFF
--- a/application/templates/cms_autosave/edit_and_preview_measure.html
+++ b/application/templates/cms_autosave/edit_and_preview_measure.html
@@ -11,10 +11,11 @@
 
 {% block title %}{{ measure.title }}{% endblock %}
 
-{% block messages %}{% include 'cms_autosave/_messages.html' %}{% endblock %}
-
 {% block main_content %}
 <main id="content" class="main">
+
+    {% include 'cms_autosave/_messages.html' %}
+
     <form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
         <div class="rd_cms_autocomplete">
             {% include 'cms_autosave/_measure_title.html' %}


### PR DESCRIPTION
Also separates out the GET and POST actions into different methods, following the https://en.wikipedia.org/wiki/Post/Redirect/Get pattern.

I've simplified the stale update error messaging for now, as I couldn't get that working. We should have a discussion as to how this ought best to work.