### PR TITLE
Show error prefix in title if there are errors

### DIFF
--- a/application/templates/_shared/_page_title.html
+++ b/application/templates/_shared/_page_title.html
@@ -1,0 +1,3 @@
+{% macro page_title(title, error=False) %}
+{{ "Error: " if error }}{{ title }}
+{% endmacro %}

--- a/application/templates/admin/add_user.html
+++ b/application/templates/admin/add_user.html
@@ -1,8 +1,10 @@
 {% extends "cms/base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
+{% from "_shared/_page_title.html" import page_title %}
+
 {% from "cms/forms.html" import render_field %}
 
-{% block page_title %}Add user{% endblock %}
+{% block page_title %}{{ page_title("Add user", error=(form.errors|length) > 0) }}{% endblock %}
 {% block body_classes %}rd_cms{% endblock %}
 
  {% block messages %}

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -1,8 +1,9 @@
 {% extends "cms/base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
+{% from "_shared/_page_title.html" import page_title %}
 
 {% block body_classes %}rd_cms{% endblock %}
-{% block page_title %}Upload file{% endblock %}
+{% block page_title %}{{ page_title("Upload file", error=(form.errors|length > 0) ) }}{% endblock %}
 
 {% block messages %}
   <div class='grid-row'>

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -1,8 +1,10 @@
 {% extends "cms/create_dimension.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
+{% from "_shared/_page_title.html" import page_title %}
+
 
 {% block body_classes %}rd_cms{% endblock %}
-{% block page_title %}Edit dimension{% endblock %}
+{% block page_title %}{{ page_title("Edit dimension", error=(form.errors|length > 0) )}}{% endblock %}
 
 {% block main_content %}
 <main class="main" id="content">

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -1,10 +1,12 @@
 {% extends "cms/base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
+{% from "_shared/_page_title.html" import page_title %}
+
 {% from "cms/forms.html" import render_field, render_textarea_field, render_contact_details_fields,
                                 render_checkboxes, render_radio_field, render_department_select %}
 
 {% block body_classes %}rd_cms{% endblock %}
-{% block page_title %}{{ measure.title }}{% endblock %}
+{% block page_title %}{{ page_title(measure.title, error=(form.errors|length > 0)) }}{% endblock %}
 
 {% block messages %}
 

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -1,8 +1,9 @@
 {% extends "cms/base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
+{% from "_shared/_page_title.html" import page_title %}
 
 {% block body_classes %}rd_cms{% endblock %}
-{% block page_title %}Edit download{% endblock %}
+{% block page_title %}{{ page_title("Edit download", error=(form.errors|length > 0) ) }}{% endblock %}
 
 {% block messages %}
   <div class='grid-row'>


### PR DESCRIPTION
See https://trello.com/c/Umqx1CW7/975-add-error-prefix-to-page-titles-on-pages-containing-errors-1