### PR TITLE
Update column name when selection changes

### DIFF
--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -239,10 +239,12 @@ $(document).ready(function () {
         (this the exact same method that is used front-end)
     */
 
-    function dataColumnChange(evt, columnName) {
-        if ($('#' + this.id + '_name').val() === "") {
-            $('#' + this.id + '_name').val($('#' + this.id + ' option:selected').val());
-        };
+    function dataColumnChange(evt) {
+        var selected_column_name = $('#' + this.id + ' option:selected').val();
+
+        var new_column_name = (selected_column_name === unselectedOptionString) ? "" : selected_column_name;
+
+        $('#' + this.id + '_name').val(new_column_name);
 
         preview(evt);
     }


### PR DESCRIPTION
 ## Summary
When a user changes the column field they want to display in their
table, the default value for that column should update to the name of
the new field.

e.g. if a user wants column 1 to be 'Ethnicity', the name of that column
is pre-populated to 'Ethnicity'. If they then change column 1 to display
'Value', the name of that column should update to 'Value'. The caveat
for this is that the name of the column won't update if they have
customised it in any way (i.e. it doesn't match the name of the column
in the data).

 ## Ticket
https://trello.com/c/NBb73L9m/994