### PR TITLE
Always require Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ MAILGUN_SMTP_PASSWORD=[ask someone who knows]
 # You only need to set these if you want to run the data migration job from production
 PROD_DB_URL=[ask someone who knows]
 PROD_UPLOAD_BUCKET_NAME=[ask someone who knows]
+
+GOOGLE_ANALYTICS_ID=[identifier for Google Analytics]
 ```
 
 **Remember**: do not commit sensitive data to the repo.

--- a/app.json
+++ b/app.json
@@ -45,6 +45,9 @@
     "GITHUB_URL": {
       "required": true
     },
+    "GOOGLE_ANALYTICS_ID": {
+      "required": true
+    },
     "HEROKU_POSTGRESQL_RED_URL": {
       "required": true
     },

--- a/application/config.py
+++ b/application/config.py
@@ -86,7 +86,7 @@ class Config:
 
     JSON_ENABLED = get_bool(os.environ.get("JSON_ENABLED", False))
 
-    GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", "")
+    GOOGLE_ANALYTICS_ID = os.environ["GOOGLE_ANALYTICS_ID"]
 
     MAIL_SERVER = os.environ.get("MAILGUN_SMTP_SERVER")
     MAIL_USE_SSL = True

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -39,7 +39,7 @@
     {% endblock %}
 
 
-    {% if static_mode and config.GOOGLE_ANALYTICS_ID %}
+    {% if static_mode %}
       <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
This requires a `GOOGLE_ANALYTICS_ID` environment variable to be present, and also always renders the Google Analytics tracking javascript in static builds.

The main justification for this is to avoid having errors in the Google Analytics tracking code which only become noticeable on our public site.