### PR TITLE
BUGFIX: Noindex being set on latest measures if newer draft exists

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -22,7 +22,7 @@
 
     {% endif %}
 
-    {% if not measure_page.latest %}
+    {% if not measure_page.has_no_later_published_versions() %}
         <meta name="robots" content="noindex">
     {% endif %}
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -401,7 +401,7 @@ def stub_measure_data():
 
 
 @pytest.fixture(scope="function")
-def stub_measure_page_one_of_two(
+def stub_measure_page_one_of_three(
     db_session,
     stub_subtopic_page,
     stub_measure_data,
@@ -412,16 +412,14 @@ def stub_measure_page_one_of_two(
     stub_organisations,
 ):
     page = Page(
-        guid="test-published-measure-page",
+        guid="test-multiversion-measure-page",
         parent_guid=stub_subtopic_page.guid,
         parent_version=stub_subtopic_page.version,
         page_type="measure",
-        uri="test-published-measure-page",
+        uri="test-multiversion-measure-page",
         status="APPROVED",
         published=True,
         version="1.0",
-        internal_edit_summary="internal_edit_summary",
-        external_edit_summary="external_edit_summary",
         area_covered=["UK"],
         department_source=stub_dept,
         lowest_level_of_geography=stub_geography,
@@ -438,7 +436,7 @@ def stub_measure_page_one_of_two(
 
 
 @pytest.fixture(scope="function")
-def stub_measure_page_two_of_two(
+def stub_measure_page_two_of_three(
     db_session,
     stub_subtopic_page,
     stub_measure_data,
@@ -449,16 +447,53 @@ def stub_measure_page_two_of_two(
     stub_organisations,
 ):
     page = Page(
-        guid="test-published-measure-page",
+        guid="test-multiversion-measure-page",
         parent_guid=stub_subtopic_page.guid,
         parent_version=stub_subtopic_page.version,
         page_type="measure",
-        uri="test-published-measure-page",
+        uri="test-multiversion-measure-page",
         status="APPROVED",
         published=True,
         version="2.0",
-        internal_edit_summary="internal_edit_summary",
-        external_edit_summary="external_edit_summary",
+        internal_edit_summary="internal_edit_summary_v2",
+        external_edit_summary="external_edit_summary_v2",
+        area_covered=["UK"],
+        department_source=stub_dept,
+        lowest_level_of_geography=stub_geography,
+        latest=False,
+        type_of_statistic_id=stub_type_of_statistic.id,
+    )
+    for key, val in stub_measure_data.items():
+        if key == "publication_date":
+            val = datetime.strptime(val, "%Y-%m-%d")
+        setattr(page, key, val)
+    db_session.session.add(page)
+    db_session.session.commit()
+    return page
+
+
+@pytest.fixture(scope="function")
+def stub_measure_page_three_of_three(
+    db_session,
+    stub_subtopic_page,
+    stub_measure_data,
+    stub_frequency,
+    stub_dept,
+    stub_geography,
+    stub_type_of_statistic,
+    stub_organisations,
+):
+    page = Page(
+        guid="test-multiversion-measure-page",
+        parent_guid=stub_subtopic_page.guid,
+        parent_version=stub_subtopic_page.version,
+        page_type="measure",
+        uri="test-multiversion-measure-page",
+        status="DRAFT",
+        published=False,
+        version="2.1",
+        internal_edit_summary="internal_edit_summary_v3",
+        external_edit_summary="external_edit_summary_v3",
         area_covered=["UK"],
         department_source=stub_dept,
         lowest_level_of_geography=stub_geography,

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 
 from application.cms.exceptions import RejectionImpossible
 from application.cms.models import Page
@@ -224,11 +225,11 @@ def test_latest_version_does_not_add_noindex_for_robots(
     mock_admin_user,
     stub_topic_page,
     stub_subtopic_page,
-    stub_measure_page_one_of_two,
-    stub_measure_page_two_of_two,
+    stub_measure_page_one_of_three,
+    stub_measure_page_two_of_three,
 ):
     # GIVEN the latest version of a page
-    latest_version_of_page = stub_measure_page_two_of_two
+    latest_version_of_page = stub_measure_page_two_of_three
     # WHEN we get the rendered template
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_admin_user.id
@@ -245,7 +246,45 @@ def test_latest_version_does_not_add_noindex_for_robots(
     )
     # THEN it should not contain a noindex tag
     assert resp.status_code == 200
-    assert '<meta name="robots" content="noindex">' not in str(resp.data)
+    page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+    robots_tags = page.find_all("meta", attrs={"name": "robots"}, content=lambda value: value and "noindex" in value)
+    assert len(robots_tags) == 0
+
+
+def test_latest_version_does_not_add_noindex_for_robots_when_newer_draft_exists(
+    app,
+    db,
+    db_session,
+    test_app_client,
+    mock_admin_user,
+    stub_topic_page,
+    stub_subtopic_page,
+    stub_measure_page_one_of_three,
+    stub_measure_page_two_of_three,
+    stub_measure_page_three_of_three,
+):
+    # GIVEN the latest version of a page and a newer draft (ie the stub_measure_page_three_of_three fixture)
+    latest_published_version_of_page = stub_measure_page_two_of_three
+
+    # WHEN we get the rendered template
+    with test_app_client.session_transaction() as session:
+        session["user_id"] = mock_admin_user.id
+    from flask import url_for
+
+    resp = test_app_client.get(
+        url_for(
+            "static_site.measure_page",
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=latest_published_version_of_page.uri,
+            version=latest_published_version_of_page.version,
+        )
+    )
+    # THEN it should not contain a noindex tag
+    assert resp.status_code == 200
+    page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+    robots_tags = page.find_all("meta", attrs={"name": "robots"}, content=lambda value: value and "noindex" in value)
+    assert len(robots_tags) == 0
 
 
 def test_previous_version_adds_noindex_for_robots(
@@ -256,11 +295,11 @@ def test_previous_version_adds_noindex_for_robots(
     mock_admin_user,
     stub_topic_page,
     stub_subtopic_page,
-    stub_measure_page_one_of_two,
-    stub_measure_page_two_of_two,
+    stub_measure_page_one_of_three,
+    stub_measure_page_two_of_three,
 ):
     # GIVEN a page with a later published version
-    outdated_page = stub_measure_page_one_of_two
+    outdated_page = stub_measure_page_one_of_three
     # WHEN we get the rendered template
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_admin_user.id
@@ -277,7 +316,9 @@ def test_previous_version_adds_noindex_for_robots(
     )
     # THEN it should contain a noindex tag
     assert resp.status_code == 200
-    assert '<meta name="robots" content="noindex">' in str(resp.data)
+    page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+    robots_tags = page.find_all("meta", attrs={"name": "robots"}, content=lambda value: value and "noindex" in value)
+    assert len(robots_tags) == 1
 
 
 def test_is_minor_or_minor_version():


### PR DESCRIPTION
Fixes this bug: https://trello.com/c/Dsj01NVV/1082-some-latest-measure-versions-are-getting-noindexed-in-error

measure_page.latest is not reliable to detect the latest *published*
version  of a measure, so we had a bug where latest published measures
are being excluded from indexing if a newer draft version has been
created in the CMS.

This fix uses the `has_no_later_published_versions()` method rather than
`.latest`, which should be a reliable way to detect if page is the
latest published version.