### PR TITLE
Fix chart/table title height on new dimensions

### DIFF
--- a/application/src/js/chartbuilder2/chartbuilder2.js
+++ b/application/src/js/chartbuilder2/chartbuilder2.js
@@ -293,6 +293,8 @@ $(document).ready(function () {
 
             $('#save_section').show();
         }
+        
+        document.getElementById('chart_title').dispatchEvent(new Event("input"));
     }
 
     /*
@@ -709,7 +711,6 @@ $(document).ready(function () {
         }
 
         $('#chart_title').val(settings.chartFormat.chart_title);
-        document.getElementById('chart_title').dispatchEvent(new Event("input"));
 
         switch (settings.type) {
             case 'line_graph':

--- a/application/src/js/tablebuilder2/tablebuilder2.js
+++ b/application/src/js/tablebuilder2/tablebuilder2.js
@@ -309,6 +309,7 @@ $(document).ready(function () {
 
             $('#save_section').show();
         }
+        document.getElementById('table_title').dispatchEvent(new Event("input"));
     }
 
     /*
@@ -630,7 +631,6 @@ $(document).ready(function () {
         }
 
         $('#table_title').val(settings.tableValues.table_title);
-        document.getElementById('table_title').dispatchEvent(new Event("input"));
         
         $('#complex-table__data-style').val(settings.tableOptions.data_style);
 


### PR DESCRIPTION
 ## Summary
When creating a new chart/table, the box for entering the title started
with a bad height (too small). This fix changes when the event for
resizing is fired by chart/table builder to every time the table is
regenerated, rather than just the first time the page is setup (which
does nothing in the case of new charts/tables.

 ## Ticket
https://trello.com/c/q2ypmIGE/1070