### PR TITLE
Bugfix: use CMS template

### DIFF
--- a/application/templates/admin/user.html
+++ b/application/templates/admin/user.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "cms/base.html" %}
 {% from "_shared/_breadcrumb.html" import breadcrumb %}
 
 {% block page_title %}User{% endblock %}


### PR DESCRIPTION
This adds the cms CSS, which is needed to style the autocomplete.

Fixes https://trello.com/c/ZQE5wmym/1091-styling-on-drop-down-autocomplete-is-broken