### PR TITLE
WTForms FTW

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -148,7 +148,7 @@ class Page(db.Model):
     version = db.Column(db.String(), nullable=False)  # combined with guid forms primary key for page table
     internal_reference = db.Column(db.String())  # optional internal reference number for measures
     latest = db.Column(db.Boolean, default=True)  # True if the current row is the latest version of a measure
-    #                                                   (latest created, not latest published, so could be a new draft)
+    #                                               (latest created, not latest published, so could be a new draft)
 
     uri = db.Column(db.String(255))  # slug to be used in URLs for the page
     review_token = db.Column(db.String())  # used for review page URLs

--- a/application/cms_autosave/forms.py
+++ b/application/cms_autosave/forms.py
@@ -70,7 +70,7 @@ class MeasurePageAutosaveForm(FlaskForm):
     suppression_and_disclosure = TextAreaField(label="Suppression rules and disclosure control")
     estimation = TextAreaField(label="Rounding")
     related_publications = TextAreaField(label="Related publications")
-    qmi_url = StringField(label="Quality Methodology Information URL")
+    qmi_url = StringField(label="Quality and methodology information")
     further_technical_information = TextAreaField(label="Further technical information")
 
     # Primary data source

--- a/application/cms_autosave/forms.py
+++ b/application/cms_autosave/forms.py
@@ -70,7 +70,7 @@ class MeasurePageAutosaveForm(FlaskForm):
     suppression_and_disclosure = TextAreaField(label="Suppression rules and disclosure control")
     estimation = TextAreaField(label="Rounding")
     related_publications = TextAreaField(label="Related publications")
-    qmi_url = StringField(label="Quality and methodology information")
+    qmi_url = URLField(label="Quality and methodology information")
     further_technical_information = TextAreaField(label="Further technical information")
 
     # Primary data source

--- a/application/templates/cms_autosave/_data_sources.html
+++ b/application/templates/cms_autosave/_data_sources.html
@@ -9,7 +9,7 @@
     <div class="accordion-section-body">
     {# PRIMARY SOURCE #}
         <h3 class="heading-small">Source</h3>
-        {{ editable_link(measure.source_text, measure.source_url, link_text_field_name="source_text", link_url_field_name="source_url", empty_message="Add link to source", tab_index=14) }}
+        {{ editable_link(link_text_field=form.source_text, link_url_field=form.source_url, empty_message="Add link to source", tab_index=14) }}
 
         <h3 class="heading-small">Type of data</h3>
         {% set primary_source_types_of_data = [] %}
@@ -41,7 +41,7 @@
     {# SECONDARY SOURCE #}
         <div class="secondary-source">
             <h3 class="heading-small">Secondary source</h3>
-            {{ editable_link(measure.secondary_source_1_title, measure.secondary_source_1_url, link_text_field_name="secondary_source_1_title", link_url_field_name="secondary_source_1_url", empty_message="Add link to secondary source", tab_index=22) }}
+            {{ editable_link(link_text_field=form.secondary_source_1_title, link_url_field=form.secondary_source_1_url, empty_message="Add link to secondary source", tab_index=22) }}
 
             <h3 class="heading-small">Type of data</h3>
             {% set secondary_source_types_of_data = [] %}

--- a/application/templates/cms_autosave/_data_sources.html
+++ b/application/templates/cms_autosave/_data_sources.html
@@ -24,19 +24,19 @@
         {{ editable_radio_field(form.type_of_statistic_id, measure.type_of_statistic_description.external, field_name="type_of_statistic_id", empty_message="Add statistic type", tab_index=16) }}
 
         <h3 class="heading-small">Publisher</h3>
-        {{ editable_department_select(form.department_source, measure.department_source.name, organisations_by_type, field_name="department_source_id", empty_message="Add publisher", tab_index=17) }}
+        {{ editable_department_select(form.department_source, organisations_by_type, value_text=measure.department_source.name, value_id=measure.department_source.id, empty_message="Add publisher", tab_index=17) }}
 
         <h3 class="heading-small">Publication release date</h3>
-        {{ editable_text(measure.published_date, field_name="published_date", empty_message="Click to add", tab_index=18) }}
+        {{ editable_text(form.published_date, empty_message="Click to add", tab_index=18) }}
 
         <h3 class="heading-small">Note on corrections or updates</h3>
-        {{ editable_textarea(measure.note_on_corrections_or_updates, field_name="note_on_corrections_or_updates", empty_message="Click to add", tab_index=19) }}
+        {{ editable_textarea(form.note_on_corrections_or_updates, empty_message="Click to add", tab_index=19) }}
 
         <h3 class="heading-small">Publication frequency</h3>
         {{ editable_radio_field(form.frequency_id, measure.frequency_of_release.description, field_name="frequency_id", empty_message="Add publication frequency", other_field=form.frequency_other, tab_index=20) }}
 
         <h3 class="heading-small">Purpose of data source</h3>
-        {{ editable_textarea(measure.data_source_purpose, field_name="data_source_purpose", empty_message="Click to add", tab_index=21) }}
+        {{ editable_textarea(form.data_source_purpose, empty_message="Click to add", tab_index=21) }}
 
     {# SECONDARY SOURCE #}
         <div class="secondary-source">
@@ -56,19 +56,19 @@
             {{ editable_radio_field(form.secondary_source_1_type_of_statistic_id, measure.secondary_source_1_type_of_statistic_description.external, field_name="secondary_source_1_type_of_statistic_id", empty_message="Add statistic type", tab_index=24) }}
 
             <h3 class="heading-small">Publisher</h3>
-            {{ editable_department_select(form.secondary_source_1_publisher, measure.secondary_source_1_publisher.name, organisations_by_type, field_name="secondary_source_1_publisher_id", empty_message="Add publisher", tab_index=25) }}
+            {{ editable_department_select(form.secondary_source_1_publisher, organisations_by_type, value_text=measure.secondary_source_1_publisher.name, value_id=measure.secondary_source_1_publisher.id, empty_message="Add publisher", tab_index=25) }}
 
             <h3 class="heading-small">Publication release date</h3>
-            {{ editable_text(measure.secondary_source_1_date, field_name="secondary_source_1_date", empty_message="Click to add", tab_index=26) }}
+            {{ editable_text(form.secondary_source_1_date, empty_message="Click to add", tab_index=26) }}
 
             <h3 class="heading-small">Note on corrections or updates</h3>
-            {{ editable_textarea(measure.secondary_source_1_note_on_corrections_or_updates, field_name="secondary_source_1_note_on_corrections_or_updates", empty_message="Click to add", tab_index=27) }}
+            {{ editable_textarea(form.secondary_source_1_note_on_corrections_or_updates, empty_message="Click to add", tab_index=27) }}
 
             <h3 class="heading-small">Publication frequency</h3>
             {{ editable_radio_field(form.secondary_source_1_frequency_id, measure.secondary_source_1_frequency_of_release.description, field_name="secondary_source_1_frequency_id", empty_message="Add publication frequency", other_field=form.secondary_source_1_frequency_other, tab_index=28) }}
 
             <h3 class="heading-small">Purpose of data source</h3>
-            {{ editable_textarea(measure.secondary_source_1_data_source_purpose, field_name="secondary_source_1_data_source_purpose", empty_message="Click to add", tab_index=29) }}
+            {{ editable_textarea(form.secondary_source_1_data_source_purpose, empty_message="Click to add", tab_index=29) }}
         </div>
     </div>
 </div>

--- a/application/templates/cms_autosave/_data_sources.html
+++ b/application/templates/cms_autosave/_data_sources.html
@@ -1,5 +1,5 @@
 {% from "cms_autosave/macros.html"
-   import editable_checkboxes, editable_link, editable_radio_field, editable_text, editable_textarea, editable_department_select
+   import editable_checkboxes, editable_link, editable_radio_field, editable_text, editable_textarea, editable_organisation_select
 %}
 
 <div class="accordion-section">
@@ -24,7 +24,7 @@
         {{ editable_radio_field(form.type_of_statistic_id, measure.type_of_statistic_description.external, field_name="type_of_statistic_id", empty_message="Add statistic type", tab_index=16) }}
 
         <h3 class="heading-small">Publisher</h3>
-        {{ editable_department_select(form.department_source, organisations_by_type, value_text=measure.department_source.name, value_id=measure.department_source.id, empty_message="Add publisher", tab_index=17) }}
+        {{ editable_organisation_select(form.department_source, organisations_by_type, value_text=measure.department_source.name, value_id=measure.department_source.id, empty_message="Add publisher", tab_index=17) }}
 
         <h3 class="heading-small">Publication release date</h3>
         {{ editable_text(form.published_date, empty_message="Click to add", tab_index=18) }}
@@ -56,7 +56,7 @@
             {{ editable_radio_field(form.secondary_source_1_type_of_statistic_id, measure.secondary_source_1_type_of_statistic_description.external, field_name="secondary_source_1_type_of_statistic_id", empty_message="Add statistic type", tab_index=24) }}
 
             <h3 class="heading-small">Publisher</h3>
-            {{ editable_department_select(form.secondary_source_1_publisher, organisations_by_type, value_text=measure.secondary_source_1_publisher.name, value_id=measure.secondary_source_1_publisher.id, empty_message="Add publisher", tab_index=25) }}
+            {{ editable_organisation_select(form.secondary_source_1_publisher, organisations_by_type, value_text=measure.secondary_source_1_publisher.name, value_id=measure.secondary_source_1_publisher.id, empty_message="Add publisher", tab_index=25) }}
 
             <h3 class="heading-small">Publication release date</h3>
             {{ editable_text(form.secondary_source_1_date, empty_message="Click to add", tab_index=26) }}

--- a/application/templates/cms_autosave/_main_commentary.html
+++ b/application/templates/cms_autosave/_main_commentary.html
@@ -1,11 +1,11 @@
-{% from "cms_autosave/macros.html" import editable_textarea_for_bullets, editable_collapsible_textarea %}
+{% from "cms_autosave/macros.html" import editable_textarea, editable_collapsible_textarea %}
 
 <div class="grid-row">
     <div class="column-two-thirds">
         <p>The main facts and figures show that:</p>
-        {{ editable_textarea_for_bullets(measure.summary, field_name="summary", empty_message="Click to add main points", tab_index=4) }}
-        {{ editable_collapsible_textarea("Things you need to know", measure.need_to_know, field_name="need_to_know", empty_message="Click to add things you need to know", tab_index=5) }}
-        {{ editable_collapsible_textarea("What the data measures", measure.measure_summary, field_name="measure_summary", empty_message="Click to add what the data measures", tab_index=6) }}
-        {{ editable_collapsible_textarea("The ethnic categories used in this data", measure.ethnicity_definition_summary, field_name="ethnicity_definition_summary", empty_message="Click to add ethnic categories used in this data", tab_index=7) }}
+        {{ editable_textarea(form.summary, class="for-bullets", empty_message="Click to add main points", tab_index=4) }}
+        {{ editable_collapsible_textarea(form.need_to_know, empty_message="Click to add things you need to know", tab_index=5) }}
+        {{ editable_collapsible_textarea(form.measure_summary, empty_message="Click to add what the data measures", tab_index=6) }}
+        {{ editable_collapsible_textarea(form.ethnicity_definition_summary, empty_message="Click to add ethnic categories used in this data", tab_index=7) }}
     </div>
 </div>

--- a/application/templates/cms_autosave/_measure_title.html
+++ b/application/templates/cms_autosave/_measure_title.html
@@ -1,6 +1,6 @@
-{% from "cms_autosave/macros.html" import editable_heading %}
+{% from "cms_autosave/macros.html" import editable_page_heading %}
 <div class="grid-row">
     <div class="column-two-thirds">
-        {{ editable_heading(measure.title, field_name="title", empty_message="Click to add Title", tab_index=0) }}
+        {{ editable_page_heading(form.title, empty_message="Click to add Title", tab_index=0) }}
     </div>
 </div>

--- a/application/templates/cms_autosave/_methodology.html
+++ b/application/templates/cms_autosave/_methodology.html
@@ -17,7 +17,7 @@
         <h3 class="heading-small">Related publications</h3>
         {{ editable_textarea(form.related_publications, empty_message="Click to add", tab_index=11) }}
 
-        {{ editable_link(link_text='Quality and methodology information', link_url=measure.qmi_url, link_text_field_name=None, link_url_field_name='qmi_url', empty_message="Click to add", tab_index=12) }}
+        {{ editable_link(link_url_field=form.qmi_url, link_text_field=None, empty_message="Click to add", tab_index=12) }}
 
         <h3 class="heading-small">Further technical information</h3>
         {{ editable_textarea(form.further_technical_information, empty_message="Click to add", tab_index=13) }}

--- a/application/templates/cms_autosave/_methodology.html
+++ b/application/templates/cms_autosave/_methodology.html
@@ -6,20 +6,20 @@
     </div>
     <div class="accordion-section-body">
         <h3 class="heading-small">Methodology</h3>
-        {{ editable_textarea(measure.methodology, field_name="methodology", empty_message="Click to add", tab_index=8) }}
+        {{ editable_textarea(form.methodology, empty_message="Click to add", tab_index=8) }}
 
         <h3 class="heading-small">Suppression rules and disclosure control</h3>
-        {{ editable_textarea(measure.suppression_and_disclosure, field_name="suppression_and_disclosure", empty_message="Click to add", tab_index=9) }}
+        {{ editable_textarea(form.suppression_and_disclosure, empty_message="Click to add", tab_index=9) }}
 
         <h3 class="heading-small">Rounding</h3>
-        {{ editable_textarea(measure.estimation, field_name="estimation", empty_message="Click to add", tab_index=10) }}
+        {{ editable_textarea(form.estimation, empty_message="Click to add", tab_index=10) }}
 
         <h3 class="heading-small">Related publications</h3>
-        {{ editable_textarea(measure.related_publications, field_name="related_publications", empty_message="Click to add", tab_index=11) }}
+        {{ editable_textarea(form.related_publications, empty_message="Click to add", tab_index=11) }}
 
         {{ editable_link(link_text='Quality and methodology information', link_url=measure.qmi_url, link_text_field_name=None, link_url_field_name='qmi_url', empty_message="Click to add", tab_index=12) }}
 
         <h3 class="heading-small">Further technical information</h3>
-        {{ editable_textarea(measure.further_technical_information, field_name="further_technical_information", empty_message="Click to add", tab_index=13) }}
+        {{ editable_textarea(form.further_technical_information, empty_message="Click to add", tab_index=13) }}
     </div>
 </div>

--- a/application/templates/cms_autosave/_public_metadata.html
+++ b/application/templates/cms_autosave/_public_metadata.html
@@ -15,7 +15,7 @@
                 <dt>Published:</dt>
                 <dd>{{ publish_date }}</dd>
                 {{ editable_metadata_dl_checkboxes("Area covered", form.area_covered, summary=measure.format_area_covered(), empty_message="Click to set areas covered", tab_index=2) }}
-                {{ editable_metadata_dl_text("Time period", measure.time_covered, field_name="time_covered", empty_message="Click to set time period", tab_index=3) }}
+                {{ editable_metadata_dl_text(form.time_covered, empty_message="Click to set time period", tab_index=3) }}
             </dl>
         </div>
     </div>

--- a/application/templates/cms_autosave/_public_metadata.html
+++ b/application/templates/cms_autosave/_public_metadata.html
@@ -14,7 +14,7 @@
                 <dd>{{ measure.department_source.name or "TBC" }} (set in &quot;Data sources&quot; below)</dd>
                 <dt>Published:</dt>
                 <dd>{{ publish_date }}</dd>
-                {{ editable_metadata_dl_checkboxes("Area covered", form.area_covered, summary=measure.format_area_covered(), empty_message="Click to set areas covered", tab_index=2) }}
+                {{ editable_metadata_dl_checkboxes(form.area_covered, summary=measure.format_area_covered(), empty_message="Click to set areas covered", tab_index=2) }}
                 {{ editable_metadata_dl_text(form.time_covered, empty_message="Click to set time period", tab_index=3) }}
             </dl>
         </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -27,20 +27,20 @@
 {%- endmacro %}
 
 
-{% macro editable_metadata_dl_text(key, value) -%}
+{% macro editable_metadata_dl_text(field) -%}
 
-    <dt>{{ key }}:</dt>
+    <dt>{{ field.label }}:</dt>
     <dd>
         <div class="preview-and-edit">
-            <span class="preview {% if not value %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-            {% if value -%}
-                {{ value }}
+            <span class="preview {% if not field.data %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+            {% if field.data -%}
+                {{ field.data }}
             {% else %}
                 {{ kwargs['empty_message'] }}
             {%- endif %}
             </span>
             <div class="edit hidden">
-                <input type="text" name="{{ kwargs['field_name'] }}" class="form-control for-metadata" value="{{ value }}" />
+                {{ field(class="form-control for-metadata") }}
                 <button class="link save">Save</button>
                 <button class="link cancel">Cancel</button>
             </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -152,28 +152,26 @@
 {%- endmacro %}
 
 
-{% macro editable_link(link_text, link_url, link_text_field_name, link_url_field_name) -%}
+{% macro editable_link(link_url_field, link_text_field=None) -%}
 
     <div class="preview-and-edit">
-        <p class="{{ 'empty' if not link_text }} preview pretend-link" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-            {% if link_text -%}
-                {{ link_text }}
+        <p class="preview pretend-link" data-empty-text="{{ link_url_field.label.text }}" tabindex={{ kwargs['tab_index'] }}>
+            {% if link_text_field and link_text_field.data -%}
+                {{ link_text_field.data }}
             {% else %}
-                {{ kwargs['empty_message'] }}
+                {{ link_url_field.label.text }}
             {%- endif %}
         </p>
         <div class="edit hidden">
             <div>
-                {% if link_text_field_name -%}
-                Link text <input type="text" name="{{ link_text_field_name }}" value="{{ link_text if link_text else '' }}" class="js-dependent" />
-                {% elif link_text -%}
-                    {{ link_text }}
+                {% if link_text_field %}
+                    Link text  {{ link_text_field(class="js-dependent") }}
                 {% else %}
-                    {{ kwargs['empty_message'] }}
-                {%- endif %}
-            </div>
+                    {{ link_url_field.label.text }}
+                {% endif %}
+                </div>
             <div>
-                URL <input type="url" name="{{ link_url_field_name }}" value="{{ link_url if link_url else '' }}" class="js-dependent" />
+                URL  {{ link_url_field(class="js-dependent") }}
             </div>
             <div>
                 <button class="link save">Save</button>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -169,7 +169,7 @@
                 {% else %}
                     {{ link_url_field.label.text }}
                 {% endif %}
-                </div>
+            </div>
             <div>
                 URL  {{ link_url_field(class="js-dependent") }}
             </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -10,7 +10,7 @@
 {% macro editable_page_heading(field) -%}
 
     <div class="preview-and-edit">
-        <h1 class="preview heading-large {% if not field.data %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+        <h1 class="preview heading-large{% if not field.data %} empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
         {% if field.data -%}
             {{ field.data }}
         {% else %}
@@ -32,7 +32,7 @@
     <dt>{{ field.label }}:</dt>
     <dd>
         <div class="preview-and-edit">
-            <span class="preview {% if not field.data %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+            <span class="preview{% if not field.data %} empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
             {% if field.data -%}
                 {{ field.data }}
             {% else %}
@@ -56,94 +56,59 @@
     <dd>
         {% call editable_checkboxes(fields, summary, **kwargs) %}
         {% endcall %}
-
     </dd>
 
 {%- endmacro %}
 
 
-{% macro editable_textarea_for_bullets(value) -%}
+{% macro editable_textarea(field, class="for-paragraphs", rows=10, cols=60) %}
 
     <div class="preview-and-edit">
-        <div class="bullets spaced-out preview {% if not value %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-            {% if value -%}
-                {{ value | render_markdown }}
-            {% else %}
-                {{ kwargs['empty_message'] }}
-            {%- endif %}
+        <div class="preview{% if not field.data %} empty{% endif %}{% if class=='for-bullets' %} bullets spaced-out{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+        {% if field.data -%}
+            {{ field.data | render_markdown }}
+        {% else %}
+            {{ kwargs['empty_message'] }}
+        {%- endif %}
         </div>
         <div class="edit hidden">
-            <textarea name="{{ kwargs['field_name'] }}" rows="10" cols="50" class="for-bullets">{% if value %}{{ value }}{% endif %}</textarea>
+            {{ field(class=class, rows=rows, cols=cols) }}
             <div>
                 <button class="link cancel">Cancel</button>
             </div>
         </div>
     </div>
 
-{%- endmacro %}
+{% endmacro %}
 
 
-{% macro editable_collapsible_textarea(title, value) -%}
+{% macro editable_collapsible_textarea(field) %}
 
     <details>
-        <summary>{{ title }}</summary>
+        <summary>{{ field.label.text }}</summary>
         <div class="panel panel-border-narrow">
-            <div class="preview-and-edit">
-              <div class="preview {% if not value %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-              {% if value -%}
-                  {{ value | render_markdown }}
-              {% else %}
-                  {{ kwargs['empty_message'] }}
-              {%- endif %}
-            </div>
-            <div class="edit hidden">
-                <textarea name="{{ kwargs['field_name'] }}" rows="5" cols="50" class="for-bullets">{% if value %}{{ value }}{% endif %}</textarea>
-                <div>
-                    <button class="link cancel">Cancel</button>
-                </div>
-            </div>
-          </div>
+            {% call editable_textarea(field, **kwargs) %}
+            {% endcall %}
         </div>
     </details>
 
-{%- endmacro %}
+{% endmacro %}
 
 
-{% macro editable_text(value) -%}
+{% macro editable_text(field) -%}
 
     <div class="preview-and-edit">
         <p class="empty preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-        {% if value -%}
-            {{ value }}
+        {% if field.data -%}
+            {{ field.data }}
         {% else %}
             {{ kwargs['empty_message'] }}
         {%- endif %}
         </p>
       <div class="edit hidden">
-          <input type="text" name="{{ kwargs['field_name'] }}" />
+          {{ field }}
           <button class="link cancel">Cancel</button>
       </div>
-    </div>
-
-{%- endmacro %}
-
-
-{% macro editable_textarea(value) -%}
-
-    <div class="preview-and-edit">
-        <div class="{{ 'empty' if not value }} preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-        {% if value -%}
-            {{ value | render_markdown }}
-        {% else %}
-            {{ kwargs['empty_message'] }}
-        {%- endif %}
-        </div>
-        <div class="edit hidden">
-            <textarea name="{{ kwargs['field_name'] }}" rows="5" cols="50" class="for-paragraphs">{% if value %}{{ value }}{% endif %}</textarea>
-            <div>
-                <button class="link cancel">Cancel</button>
-            </div>
-        </div>
     </div>
 
 {%- endmacro %}
@@ -268,11 +233,11 @@
 {%- endmacro %}
 
 
-{% macro editable_department_select(field, value, organisations_by_type) -%}
+{% macro editable_department_select(field, organisations_by_type, value_text=None, value_id=None) -%}
     <div class="preview-and-edit">
         <p class="empty preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-        {% if value -%}
-            {{ value }}
+        {% if value_text -%}
+            {{ value_text }}
         {% else %}
             {{ kwargs['empty_message'] }}
         {%- endif %}
@@ -280,8 +245,9 @@
         <div class="edit hidden">
             {{ render_department_select('',
                                         field,
-                                        measure.department_source_id if measure else None,
-                                        organisations_by_type) }}
+                                        value_id if value_id else None,
+                                        organisations_by_type,
+                                        field_name=field.name) }}
             <div>
                 <button class="link cancel">Cancel</button>
             </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -50,9 +50,9 @@
 {%- endmacro %}
 
 
-{% macro editable_metadata_dl_checkboxes(key, fields, summary=None ) -%}
+{% macro editable_metadata_dl_checkboxes(fields, summary=None ) -%}
 
-    <dt>{{ key }}:</dt>
+    <dt>{{ fields.label }}:</dt>
     <dd>
         {% call editable_checkboxes(fields, summary, **kwargs) %}
         {% endcall %}

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -1,25 +1,24 @@
 {#
     Form macros used by the cms_autosave page
     All form field macros here expect the following kwargs to be supplied when called:
-      * field_name
       * empty_message
       * tab_index
 #}
 
 {% from "cms/forms.html" import render_department_select %}
 
-{% macro editable_heading(heading_text, heading_level='h1') -%}
+{% macro editable_page_heading(field) -%}
 
     <div class="preview-and-edit">
-        <{{ heading_level }} class="preview {% if heading_level=='h1' %}heading-large{% else %}heading-medium{% endif %} {% if not heading_text %}empty{% endif %}" data-empty-text="Click to add title" tabindex={{ kwargs['tab_index'] }}>
-        {% if heading_text -%}
-            {{ heading_text }}
+        <h1 class="preview heading-large {% if not field.data %}empty{% endif %}" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
+        {% if field.data -%}
+            {{ field.data }}
         {% else %}
-            kwargs['empty_message']
+            {{ kwargs['empty_message'] }}
         {%- endif %}
-        </{{ heading_level }}>
+        </h1>
         <div class="edit hidden">
-            <input type="text" name="{{ kwargs['field_name'] }}" class="form-control for-heading" value="{{ heading_text }}" />
+            {{ field(class="form-control for-heading") }}
             <button class="link save">Save</button>
             <button class="link cancel">Cancel</button>
         </div>

--- a/application/templates/cms_autosave/macros.html
+++ b/application/templates/cms_autosave/macros.html
@@ -231,11 +231,11 @@
 {%- endmacro %}
 
 
-{% macro editable_department_select(field, organisations_by_type, value_text=None, value_id=None) -%}
+{% macro editable_organisation_select(field, organisations_by_type, selected_organisation_name=None, selected_organisation_id=None) -%}
     <div class="preview-and-edit">
         <p class="empty preview" data-empty-text="{{ kwargs['empty_message'] }}" tabindex={{ kwargs['tab_index'] }}>
-        {% if value_text -%}
-            {{ value_text }}
+        {% if selected_organisation_name -%}
+            {{ selected_organisation_name }}
         {% else %}
             {{ kwargs['empty_message'] }}
         {%- endif %}
@@ -243,7 +243,7 @@
         <div class="edit hidden">
             {{ render_department_select('',
                                         field,
-                                        value_id if value_id else None,
+                                        selected_organisation_id,
                                         organisations_by_type,
                                         field_name=field.name) }}
             <div>


### PR DESCRIPTION
For this ticket: https://trello.com/c/XSNEm6Fa/1064-cms-in-page-edit-fix-the-macros-to-use-wtforms-properly

This makes all the macros for the CMS in-page edit use the WTForm fields rather than hand-rolling the form and hope that it matches up with the fields.

See further comments on this PR, which have now all been addressed: https://github.com/racedisparityaudit/rd_cms/pull/783