### PR TITLE
BUGFIX grouped bar chart upgrade v1 to v2

### DIFF
--- a/application/data/charts.py
+++ b/application/data/charts.py
@@ -1,3 +1,6 @@
+from numbers import Number
+
+
 class ChartObjectDataBuilder:
     @staticmethod
     def build(chart_object):
@@ -136,8 +139,10 @@ class ChartObjectDataBuilder:
     def get_grouped_data_ethnicity_is_group(bar_column, chart_object):
         data = [["Ethnicity", bar_column, "Value"]]
         for series in chart_object["series"]:
-            for item in series["data"]:
-                if "text" in item and item["text"] != "number":
+            for index, item in enumerate(series["data"]):
+                if isinstance(item, Number):
+                    data += [[chart_object["xAxis"]["categories"][index], series["name"], item]]
+                elif "text" in item and item["text"] != "number":
                     data += [[item["category"], series["name"], item["text"]]]
                 else:
                     data += [[item["category"], series["name"], item["y"]]]
@@ -147,12 +152,13 @@ class ChartObjectDataBuilder:
     def get_grouped_data_ethnicity_is_bar(group_column, chart_object):
         data = [["Ethnicity", group_column, "Value"]]
         for series in chart_object["series"]:
-            for item in series["data"]:
-                if "text" in item and item["text"] != "number":
+            for index, item in enumerate(series["data"]):
+                if isinstance(item, Number):
+                    data += [[chart_object["xAxis"]["categories"][index], series["name"], item]]
+                elif "text" in item and item["text"] != "number":
                     data += [[series["name"], item["category"], item["text"]]]
                 else:
                     data += [[series["name"], item["category"], item["y"]]]
-
         return data
 
     @staticmethod


### PR DESCRIPTION
The chartbuilder v1 to v2 upgrade currently expects v1 grouped bar
charts to have a list of objects as series data.  However, a small
number of grouped bar charts have a list of numbers (int or float), and
wen the upgrade is attempted on these charts it fails with a 500 error.

The additional check here allows these "number-list" v1 charts to upgrade
to v2 charts properly.