### PR TITLE
Fix XSS vulnerability in markdown fields

### DIFF
--- a/application/static_site/filters.py
+++ b/application/static_site/filters.py
@@ -1,3 +1,4 @@
+import bleach
 import json
 import markdown
 import jinja2
@@ -9,7 +10,7 @@ from slugify import slugify
 
 
 def render_markdown(string):
-    return Markup(markdown.markdown(string))
+    return Markup(markdown.markdown(bleach.clean(string)))
 
 
 def breadcrumb_friendly(slug):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Babel==2.5.3
 bcrypt==3.1.4
 beautifulsoup4==4.6.0
 bidict==0.17.2
+bleach==3.0.0
 blinker==1.4
 boto3==1.7.35
 botocore==1.10.35       # Required by boto3

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -1,0 +1,18 @@
+import pytest
+
+from application.static_site.filters import render_markdown
+
+
+class TestRenderMarkdown:
+    @pytest.mark.parametrize(
+        "input_text, expected_output", (("hello", "<p>hello</p>"), ("* blah", "<ul>\n<li>blah</li>\n</ul>"))
+    )
+    def test_markdown_is_expanded(self, input_text, expected_output):
+        assert render_markdown(input_text) == expected_output
+
+    @pytest.mark.parametrize(
+        "input_text, expected_output",
+        (("<script>alert(1);</script>", "<p>&lt;script&gt;alert(1);&lt;/script&gt;</p>"),),
+    )
+    def test_html_is_escaped(self, input_text, expected_output):
+        assert render_markdown(input_text) == expected_output


### PR DESCRIPTION
 ## Summary
Some of our measure page fields allow markdown to be used for text
formatting. Unfortunately, the user input wasn't sanitised to check for
arbitrary HTML before being markdown'd and then marked as safe for
Jinja2 to render without escaping. This meant that any text entered into
those fields was potentially exploitable to run code on a client's
browser. The key weakness here was the `render_markdown` function - only
fields which used this function in the HTML template were susceptible to
injection.

This patch updates the function to first sanitise the input text using
the `bleach` library, which is recommended by Python's markdown module
after they deprecated their own sanitisation process.

 ## Ticket
https://trello.com/c/YDfgaTGi/1080