### PR TITLE
Check `data.sort_values` exists

### DIFF
--- a/application/templates/static_site/_table.html
+++ b/application/templates/static_site/_table.html
@@ -103,16 +103,17 @@
         <tr>
           {% set row_loop = loop %}
           {% for value in data['values'] %}
-
-          {% if data.sort_values[loop.index0] in missing_data_sort_order_values %}
-            {% set sort_value = missing_data_sort_order_values[data.sort_values[loop.index0]] %}
-          {% elif data.sort_values[loop.index0] %}
-            {% set sort_value = data.sort_values[loop.index0] %}
-          {% else %}
             {% set sort_value = value %}
-          {% endif %}
+            
+            {% if data.sort_values %}
+              {% if data.sort_values[loop.index0] in missing_data_sort_order_values %}
+                {% set sort_value = missing_data_sort_order_values[data.sort_values[loop.index0]] %}
+              {% elif data.sort_values[loop.index0] %}
+                {% set sort_value = data.sort_values[loop.index0] %}
+              {% endif %}
+            {% endif %}
 
-          {% set width = 100 /(loop.length + 1) %}
+            {% set width = 100 /(loop.length + 1) %}
 
             {% if loop.first %}
               {% set data_order = data.order if data.order else row_loop.index0 %}


### PR DESCRIPTION
 ## Summary
We've had some build failures on dev and staging where `data` doesn't
have any `sort_values`, causing the template to fail to render. This
adds a check to see whether or not `sort_values` exists before trying to
reference keys within it.