### PR TITLE
Bugfix table header alignment

### DIFF
--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -726,8 +726,8 @@ $dashboard-background-bold: #BFC1C3;
 
 
 /* Measure progress table */
-.measure-table td, th {
-  text-align: left !important;
+.measure-table td, .measure-table th {
+  text-align: left;
 }
 
 .progress__title {

--- a/application/src/static/stylesheets/measures_dashboard.css
+++ b/application/src/static/stylesheets/measures_dashboard.css
@@ -1,3 +1,0 @@
-.measure-table td,th{text-align:left !important}.progress__title{margin-bottom:40px}.progress__explanatory-text{margin-bottom:30px}.progress__explanatory-text__link,.progress__explanatory-text__link:link,.progress__explanatory-text__link:visited{color:#000;text-decoration:none;cursor:pointer;font-weight:700}.progress__explanatory-text__link:hover{text-decoration:underline}.progress-card{height:80px;background-color:#f5f5f5;text-align:center;padding:10px;margin-bottom:20px;border-radius:3px}.progress-card--selected{color:white;background-color:#005ea5}.progress-card--active:hover{background-color:#BFC1C3;color:#fff;cursor:pointer}.progress-card__value{font-size:5rem}
-
-/*# sourceMappingURL=measures_dashboard.css.map */

--- a/application/templates/dashboards/measure_progress.html
+++ b/application/templates/dashboards/measure_progress.html
@@ -10,7 +10,6 @@
 {% block pageTitle %}Planned pages - GOV.UK Ethnicity facts and figures{% endblock %}
 
 {% block content %}
-    <link rel="stylesheet" href="{{ url_for('static', filename='stylesheets/measures_dashboard.css') }}">
     <div class="progress">
         <div class="progress__title heading-xlarge">
             Planned pages


### PR DESCRIPTION
This fixes this bug: https://trello.com/c/eIpisGbx/1102-headers-in-tables-are-left-aligned-should-be-right-aligned

(Only affected pages when viewed in the Flask app, not in the static build)