### PR TITLE
Raise build exceptions to stderr

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,6 +13,7 @@ pytest-flask==0.10.0
 pytest-mock==1.10.0
 requests-mock==1.5.2
 selenium==3.8.0
+stopit==1.1.2
 testfixtures==6.2.0
 text-unidecode==1.2   # Required by Faker
 black==18.6b4

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,18 @@
+from unittest import mock
+import pytest
+import stopit
+
+from application.sitebuilder.build_service import build_site, request_build
+from tests.utils import GeneralTestException
+
+
+def test_build_exceptions_not_suppressed(app):
+    with mock.patch("application.sitebuilder.build_service.do_it") as do_it_patch:
+        do_it_patch.side_effect = GeneralTestException("build error")
+
+        request_build()
+
+        with pytest.raises(GeneralTestException) as e, stopit.SignalTimeout(1):
+            build_site(app)
+
+        assert str(e.value) == "build error"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,2 +1,6 @@
-class UnmockedRequestException(Exception):
+class GeneralTestException(Exception):
+    pass
+
+
+class UnmockedRequestException(GeneralTestException):
     pass


### PR DESCRIPTION
 ## Summary
If a build fails, our process captures the exception and supresses
it, injecting the stacktrace into the relevant build record in the
database. This record is then scraped later on by an hourly
cronjob, which then emails devs.

When a build fails locally, there's no significant indication that
anything went wrong - you have to always remember to look in the
database to see if it succeeded. This has caught us out a few times.

We want build errors to be reported immediately to stdout/stderr,
which can then be monitored by sentry to provide immediate alerts
on build failures. It also helps testing local builds as the error
isn't hidden.

 ## Ticket
https://trello.com/c/5KZOCGf7/1109