### PR TITLE
Fix block name for social description

### DIFF
--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -11,7 +11,7 @@
 
 {% block pageTitle %}{{ measure_page.title }} - GOV.UK Ethnicity facts and figures{% endblock %}
 {% block socialTitle %}{{ measure_page.title }}{% endblock %}
-{% block socialImage %}{{ measure_page.summary | first_bullet | render_markdown | striptags }}{% endblock %}
+{% block socialDescription %}{{ measure_page.summary | first_bullet | render_markdown | striptags }}{% endblock %}
 {% block googleAnalytics %}ga('set','contentGroup1','Measure');{% endblock %}
 
 {% block headEnd %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,7 +373,7 @@ def stub_measure_data():
         "contact_name": "Jane Doe",
         "contact_email": "janedoe@example.com",
         "contact_phone": "",
-        "summary": "Unemployment Summary",
+        "summary": "Unemployment Summary\n * This is a summary bullet",
         "frequency": "Quarterly",
         "frequency_id": 1,
         "qmi_url": "http://www.quality-street.gov.uk",

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -11,6 +11,8 @@ from application.cms.models import Page, Upload
 from application.cms.page_service import PageService
 from application.sitebuilder.models import Build
 
+from tests.conftest import stub_measure_data
+
 
 def test_create_measure_page(
     test_app_client,
@@ -601,7 +603,7 @@ def test_view_edit_measure_page(test_app_client, mock_rdu_user, stub_topic_page,
 
     summary = page.find("textarea", attrs={"id": "summary"})
     assert summary
-    assert summary.text == "Unemployment Summary"
+    assert summary.text == stub_measure_data()["summary"]
 
     need_to_know = page.find("textarea", attrs={"id": "need_to_know"})
     assert need_to_know


### PR DESCRIPTION
 ## Summary
During the consolidation of the base templates, we accidentally set the
social image contents to be the measure's description, which gives bad
social sharing links. This correctly puts the measure's description in
the `socialDescription` block.