### PR TITLE
Bump to flask v1.0.2

### DIFF
--- a/application/config.py
+++ b/application/config.py
@@ -116,6 +116,7 @@ class DevConfig(Config):
     LOG_LEVEL = logging.DEBUG
     ENVIRONMENT = "DEVELOPMENT"
     SESSION_COOKIE_SECURE = False
+    SESSION_COOKIE_DOMAIN = False
     SERVER_NAME = "localhost:5000"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cffi==1.11.4
 chardet==3.0.4
 click==6.7
 docutils==0.14
-Flask==0.12.4
+Flask==1.0.2
 Flask-BabelEx==0.9.3
 Flask-Login==0.4.1
 Flask-Mail==0.9.1


### PR DESCRIPTION
 ## Summary
This brings our Flask version up to 1.0.2. By not sending `SERVER_NAME`
as the Cookie Domain back in responses in development environments, we
can avoid the warning that Flask generates around cookies not being
valid for domains without at least two components (i.e. one `.`
separator).

The other option is that we all run Flask locally via a dotted domain,
e.g. `local.host` and add this to our hosts file. Unfortunately it
doesn't seem possible to get Heroku to add an entry to its own host file
when under test, so we would still be running all our tests with the
`localhost` domain. It feels better to keep dev+test more closely
aligned, so have opted for this implementation. Open to suggestions.

 ## Ticket
https://trello.com/c/aH8nJmM5/1107