### PR TITLE
Use URIs instead of GUIDs in URLs

### DIFF
--- a/application/cms/models.py
+++ b/application/cms/models.py
@@ -5,7 +5,7 @@ from functools import total_ordering
 
 import sqlalchemy
 from bidict import bidict
-from sqlalchemy import ForeignKeyConstraint, PrimaryKeyConstraint, UniqueConstraint, ForeignKey, not_
+from sqlalchemy import ForeignKeyConstraint, PrimaryKeyConstraint, UniqueConstraint, ForeignKey, not_, Index
 from sqlalchemy.dialects.postgresql import JSON, ARRAY
 from sqlalchemy.orm import relation, relationship, backref
 from sqlalchemy.orm.exc import NoResultFound
@@ -185,6 +185,7 @@ class Page(db.Model):
         PrimaryKeyConstraint("guid", "version", name="page_guid_version_pk"),
         ForeignKeyConstraint([parent_guid, parent_version], ["page.guid", "page.version"]),
         UniqueConstraint("guid", "version", name="uix_page_guid_version"),
+        Index("ix_page_type_uri", page_type, uri),
         {},
     )
 

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -158,9 +158,14 @@ class PageService(Service):
             self.logger.exception(e)
             raise PageNotFoundException()
 
-    def get_page_by_uri_and_type(self, uri, page_type):
+    def get_page_by_uri_and_type(self, uri, page_type, version=None):
         try:
-            return Page.query.filter_by(uri=uri, page_type=page_type).one()
+            query = Page.query.filter_by(uri=uri, page_type=page_type)
+
+            if version:
+                query = query.filter_by(version=version)
+
+            return query.one()
         except NoResultFound as e:
             self.logger.exception(e)
             raise PageNotFoundException()
@@ -184,9 +189,9 @@ class PageService(Service):
 
     def get_measure_page_hierarchy(self, topic, subtopic, measure, version, dimension=None, upload=None):
         try:
-            topic_page = page_service.get_page(topic)
-            subtopic_page = page_service.get_page(subtopic)
-            measure_page = page_service.get_page_with_version(measure, version)
+            topic_page = page_service.get_page_by_uri_and_type(topic, "topic")
+            subtopic_page = page_service.get_page_by_uri_and_type(subtopic, "subtopic")
+            measure_page = page_service.get_page_by_uri_and_type(measure, "measure", version)
             dimension_object = measure_page.get_dimension(dimension) if dimension else None
             upload_object = measure_page.get_upload(upload) if upload else None
         except PageNotFoundException:

--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -171,8 +171,8 @@ class PageService(Service):
             raise PageNotFoundException()
 
     @staticmethod
-    def get_measure_page_versions(parent_guid, guid):
-        return Page.query.filter_by(parent_guid=parent_guid, guid=guid).all()
+    def get_measure_page_versions(parent_guid, measure_uri):
+        return Page.query.filter_by(parent_guid=parent_guid, uri=measure_uri).all()
 
     def get_page_with_version(self, guid, version):
         try:
@@ -187,21 +187,23 @@ class PageService(Service):
             self.logger.exception(e)
             raise PageNotFoundException()
 
-    def get_measure_page_hierarchy(self, topic, subtopic, measure, version, dimension=None, upload=None):
+    def get_measure_page_hierarchy(
+        self, topic_uri, subtopic_uri, measure_uri, version, dimension_guid=None, upload_guid=None
+    ):
         try:
-            topic_page = page_service.get_page_by_uri_and_type(topic, "topic")
-            subtopic_page = page_service.get_page_by_uri_and_type(subtopic, "subtopic")
-            measure_page = page_service.get_page_by_uri_and_type(measure, "measure", version)
-            dimension_object = measure_page.get_dimension(dimension) if dimension else None
-            upload_object = measure_page.get_upload(upload) if upload else None
+            topic_page = page_service.get_page_by_uri_and_type(topic_uri, "topic")
+            subtopic_page = page_service.get_page_by_uri_and_type(subtopic_uri, "subtopic")
+            measure_page = page_service.get_page_by_uri_and_type(measure_uri, "measure", version=version)
+            dimension_object = measure_page.get_dimension(dimension_guid) if dimension_guid else None
+            upload_object = measure_page.get_upload(upload_guid) if upload_guid else None
         except PageNotFoundException:
-            self.logger.exception("Page id: {} not found".format(measure))
+            self.logger.exception("Page id: {} not found".format(measure_uri))
             raise InvalidPageHierarchy
         except UploadNotFoundException:
-            self.logger.exception("Upload id: {} not found".format(upload))
+            self.logger.exception("Upload id: {} not found".format(upload_guid))
             raise InvalidPageHierarchy
         except DimensionNotFoundException:
-            self.logger.exception("Dimension id: {} not found".format(dimension))
+            self.logger.exception("Dimension id: {} not found".format(dimension_guid))
             raise InvalidPageHierarchy
 
         # Check the topic and subtopics in the URL are the right ones for the measure
@@ -257,17 +259,11 @@ class PageService(Service):
             message = 'Page "{}" can not be updated'.format(page.title)
         return message
 
-    def get_page_by_uri_and_version(self, subtopic, measure, version):
+    def get_latest_version(self, topic_uri, subtopic_uri, measure_uri):
         try:
-            return Page.query.filter_by(parent_guid=subtopic, uri=measure, version=version).one()
-        except NoResultFound as e:
-            self.logger.exception(e)
-            raise PageNotFoundException()
-
-    def get_latest_version(self, subtopic, measure):
-        try:
-            pages = Page.query.filter_by(parent_guid=subtopic, uri=measure).all()
-            pages.sort(reverse=True)
+            topic = Page.query.filter_by(uri=topic_uri).one()
+            subtopic = Page.query.filter_by(uri=subtopic_uri, parent_guid=topic.guid).one()
+            pages = Page.query.filter_by(uri=measure_uri, parent_guid=subtopic.guid).all()
             if len(pages) > 0:
                 return pages[0]
             else:
@@ -306,9 +302,8 @@ class PageService(Service):
 
         return False, message
 
-    def create_copy(self, page_id, version, version_type, created_by):
-
-        page = self.get_page_with_version(page_id, version)
+    def create_copy(self, page_guid, page_version, version_type, created_by):
+        page = self.get_page_with_version(page_guid, page_version)
         next_version = page.next_version_number_by_type(version_type)
 
         if version_type != "copy" and self.already_updating(page.guid, next_version):
@@ -371,7 +366,7 @@ class PageService(Service):
             db.session.add(previous_page)
             db.session.commit()
 
-        upload_service.copy_uploads(page, version, original_guid)
+        upload_service.copy_uploads(page, page_version, original_guid)
 
         return page
 
@@ -390,10 +385,6 @@ class PageService(Service):
             db.session.add(previous_version)
         db.session.delete(page)
         db.session.commit()
-
-    @staticmethod
-    def get_measure_page_versions(parent_guid, guid):
-        return Page.query.filter_by(parent_guid=parent_guid, guid=guid).all()
 
     @staticmethod
     def get_pages_by_type(page_type):

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -64,13 +64,13 @@ def index():
     return redirect(url_for("static_site.index"))
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/measure/new", methods=["GET", "POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/measure/new", methods=["GET", "POST"])
 @login_required
 @user_can(CREATE_MEASURE)
-def create_measure_page(topic, subtopic):
+def create_measure_page(topic_uri, subtopic_uri):
     try:
-        topic_page = page_service.get_page_by_uri_and_type(topic, "topic")
-        subtopic_page = page_service.get_page_by_uri_and_type(subtopic, "subtopic")
+        topic_page = page_service.get_page_by_uri_and_type(topic_uri, "topic")
+        subtopic_page = page_service.get_page_by_uri_and_type(subtopic_uri, "subtopic")
     except PageNotFoundException:
         abort(404)
 
@@ -104,9 +104,9 @@ def create_measure_page(topic, subtopic):
             return redirect(
                 url_for(
                     "cms.edit_measure_page",
-                    topic=topic_page.uri,
-                    subtopic=subtopic_page.uri,
-                    measure=page.uri,
+                    topic_uri=topic_page.uri,
+                    subtopic_uri=subtopic_page.uri,
+                    measure_uri=page.uri,
                     version=page.version,
                 )
             )
@@ -130,12 +130,12 @@ def create_measure_page(topic, subtopic):
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/uploads/<upload>/delete", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/uploads/<upload>/delete", methods=["GET"])
 @login_required
 @user_has_access
-def delete_upload(topic, subtopic, measure, version, upload):
+def delete_upload(topic_uri, subtopic_uri, measure_uri, version, upload):
     *_, measure_page, upload_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, upload=upload
+        topic_uri, subtopic_uri, measure_uri, version, upload=upload
     )
 
     upload_service.delete_upload_obj(measure_page, upload_object)
@@ -144,15 +144,25 @@ def delete_upload(topic, subtopic, measure, version, upload):
     current_app.logger.info(message)
     flash(message, "info")
 
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/uploads/<upload>/edit", methods=["GET", "POST"])
+@cms_blueprint.route(
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/uploads/<upload>/edit", methods=["GET", "POST"]
+)
 @login_required
 @user_has_access
-def edit_upload(topic, subtopic, measure, version, upload):
+def edit_upload(topic_uri, subtopic_uri, measure_uri, version, upload):
     topic_page, subtopic_page, measure_page, upload_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, upload=upload
+        topic_uri, subtopic_uri, measure_uri, version, upload=upload
     )
 
     form = UploadForm(obj=upload_object)
@@ -166,7 +176,13 @@ def edit_upload(topic, subtopic, measure, version, upload):
                 message = "Updated upload {}".format(upload_object.title)
                 flash(message, "info")
                 return redirect(
-                    url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version)
+                    url_for(
+                        "cms.edit_measure_page",
+                        topic_uri=topic_uri,
+                        subtopic_uri=subtopic_uri,
+                        measure_uri=measure_uri,
+                        version=version,
+                    )
                 )
             except UploadCheckError as e:
                 message = "Error uploading file. {}".format(str(e))
@@ -183,12 +199,12 @@ def edit_upload(topic, subtopic, measure, version, upload):
     return render_template("cms/edit_upload.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/delete", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete", methods=["GET"])
 @login_required
 @user_has_access
-def delete_dimension(topic, subtopic, measure, version, dimension):
+def delete_dimension(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     *_, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_service.delete_dimension(measure_page, dimension_object.guid)
@@ -197,7 +213,15 @@ def delete_dimension(topic, subtopic, measure, version, dimension):
     current_app.logger.info(message)
     flash(message, "info")
 
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
 def _diff_updates(form, page):
@@ -216,11 +240,11 @@ def _diff_updates(form, page):
     return diffs
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/edit", methods=["GET", "POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/edit", methods=["GET", "POST"])
 @login_required
 @user_has_access
-def edit_measure_page(topic, subtopic, measure, version):
-    *_, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def edit_measure_page(topic_uri, subtopic_uri, measure_uri, version):
+    *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
     topics = page_service.get_pages_by_type("topic")
     topics.sort(key=lambda page: page.title)
     diffs = {}
@@ -318,9 +342,9 @@ def edit_measure_page(topic, subtopic, measure, version):
         return redirect(
             url_for(
                 "cms.send_to_review",
-                topic=measure_page.parent.parent.uri,
-                subtopic=measure_page.parent.uri,
-                measure=measure_page.uri,
+                topic_uri=measure_page.parent.parent.uri,
+                subtopic_uri=measure_page.parent.uri,
+                measure_uri=measure_page.uri,
                 version=measure_page.version,
             )
         )
@@ -328,9 +352,9 @@ def edit_measure_page(topic, subtopic, measure, version):
         return redirect(
             url_for(
                 "cms.edit_measure_page",
-                topic=measure_page.parent.parent.uri,
-                subtopic=measure_page.parent.uri,
-                measure=measure_page.uri,
+                topic_uri=measure_page.parent.parent.uri,
+                subtopic_uri=measure_page.parent.uri,
+                measure_uri=measure_page.uri,
                 version=measure_page.version,
             )
         )
@@ -350,12 +374,14 @@ def edit_measure_page(topic, subtopic, measure, version):
     return render_template("cms/edit_measure_page.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/upload", methods=["GET", "POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/upload", methods=["GET", "POST"])
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def create_upload(topic, subtopic, measure, version):
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def create_upload(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     form = UploadForm()
     if request.method == "POST":
@@ -367,7 +393,7 @@ def create_upload(topic, subtopic, measure, version):
                     page=measure_page, upload=f, title=form.data["title"], description=form.data["description"]
                 )
 
-                message = 'Uploaded file "{}" to measure "{}"'.format(upload.title, measure)
+                message = 'Uploaded file "{}" to measure "{}"'.format(upload.title, measure_uri)
                 current_app.logger.info(message)
                 flash(message, "info")
 
@@ -379,19 +405,27 @@ def create_upload(topic, subtopic, measure, version):
                 return render_template("cms/create_upload.html", **context)
 
             return redirect(
-                url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version)
+                url_for(
+                    "cms.edit_measure_page",
+                    topic_uri=topic_uri,
+                    subtopic_uri=subtopic_uri,
+                    measure_uri=measure_uri,
+                    version=version,
+                )
             )
 
     context = {"form": form, "topic": topic_page, "subtopic": subtopic_page, "measure": measure_page}
     return render_template("cms/create_upload.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/send-to-review", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/send-to-review", methods=["GET"])
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def send_to_review(topic, subtopic, measure, version):
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def send_to_review(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     # in case user tries to directly GET this page
     if measure_page.status == "DEPARTMENT_REVIEW":
@@ -495,15 +529,23 @@ def send_to_review(topic, subtopic, measure, version):
     current_app.logger.info(message)
     flash(message, "info")
 
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/publish", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/publish", methods=["GET"])
 @login_required
 @user_has_access
 @user_can(PUBLISH)
-def publish(topic, subtopic, measure, version):
-    *_, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def publish(topic_uri, subtopic_uri, measure_uri, version):
+    *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
 
     if measure_page.status != "DEPARTMENT_REVIEW":
         abort(400)
@@ -512,15 +554,23 @@ def publish(topic, subtopic, measure, version):
     current_app.logger.info(message)
     _build_if_necessary(measure_page)
     flash(message, "info")
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/reject")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/reject")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def reject_page(topic, subtopic, measure, version):
-    *_, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def reject_page(topic_uri, subtopic_uri, measure_uri, version):
+    *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
 
     # Can only reject if currently under review
     if measure_page.status not in {"INTERNAL_REVIEW", "DEPARTMENT_REVIEW"}:
@@ -529,46 +579,74 @@ def reject_page(topic, subtopic, measure, version):
     message = page_service.reject_page(measure_page.guid, version)
     flash(message, "info")
     current_app.logger.info(message)
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/unpublish")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/unpublish")
 @login_required
 @user_has_access
 @user_can(PUBLISH)
-def unpublish_page(topic, subtopic, measure, version):
-    *_, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def unpublish_page(topic_uri, subtopic_uri, measure_uri, version):
+    *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
 
     # Can only unpublish if currently published
     if measure_page.status != "APPROVED":
         abort(400)
 
-    page, message = page_service.unpublish(measure, version, current_user.email)
+    page, message = page_service.unpublish(measure_page.guid, version, current_user.email)
     _build_if_necessary(page)
     flash(message, "info")
     current_app.logger.info(message)
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/draft")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/draft")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def send_page_to_draft(topic, subtopic, measure, version):
-    *_, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def send_page_to_draft(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     message = page_service.send_page_to_draft(measure_page.guid, version)
     flash(message, "info")
     current_app.logger.info(message)
-    return redirect(url_for("cms.edit_measure_page", topic=topic, subtopic=subtopic, measure=measure, version=version))
+    return redirect(
+        url_for(
+            "cms.edit_measure_page",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+        )
+    )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/dimension/new", methods=["GET", "POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/dimension/new", methods=["GET", "POST"])
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def create_dimension(topic, subtopic, measure, version):
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def create_dimension(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     form = DimensionForm()
     if request.method == "POST":
@@ -593,11 +671,11 @@ def create_dimension(topic, subtopic, measure, version):
                 return redirect(
                     url_for(
                         "cms.edit_dimension",
-                        topic=topic,
-                        subtopic=subtopic,
-                        measure=measure,
+                        topic_uri=topic_uri,
+                        subtopic_uri=subtopic_uri,
+                        measure_uri=measure_uri,
                         version=version,
-                        dimension=dimension.guid,
+                        dimension_guid=dimension.guid,
                     )
                 )
             except (DimensionAlreadyExists):
@@ -607,9 +685,9 @@ def create_dimension(topic, subtopic, measure, version):
                 return redirect(
                     url_for(
                         "cms.create_dimension",
-                        topic=topic,
-                        subtopic=subtopic,
-                        measure=measure,
+                        topic_uri=topic_uri,
+                        subtopic_uri=subtopic_uri,
+                        measure_uri=measure_uri,
                         version=version,
                         messages=[{"message": "Dimension with code %s already exists" % form.data["title"]}],
                     )
@@ -628,13 +706,15 @@ def create_dimension(topic, subtopic, measure, version):
     return render_template("cms/create_dimension.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/edit", methods=["GET", "POST"])
+@cms_blueprint.route(
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/edit", methods=["GET", "POST"]
+)
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def edit_dimension(topic, subtopic, measure, version, dimension):
+def edit_dimension(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     current_cat_link = categorisation_service.get_categorisation_link_for_dimension_by_family(
@@ -645,16 +725,16 @@ def edit_dimension(topic, subtopic, measure, version, dimension):
         form = DimensionForm(request.form)
         if form.validate():
             dimension_service.update_dimension(dimension=dimension_object, data=form.data)
-            message = 'Updated dimension "{}" of measure "{}"'.format(dimension_object.title, measure)
+            message = 'Updated dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
 
             flash(message, "info")
             return redirect(
                 url_for(
                     "cms.edit_dimension",
-                    topic=topic,
-                    subtopic=subtopic,
-                    measure=measure,
-                    dimension=dimension,
+                    topic_uri=topic_uri,
+                    subtopic_uri=subtopic_uri,
+                    measure_uri=measure_uri,
+                    dimension_guid=dimension_guid,
                     version=version,
                 )
             )
@@ -681,13 +761,13 @@ def edit_dimension(topic, subtopic, measure, version, dimension):
     return render_template("cms/edit_dimension.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/chartbuilder")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/chartbuilder")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def chartbuilder(topic, subtopic, measure, version, dimension):
+def chartbuilder(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_dict = dimension_object.to_dict()
@@ -696,28 +776,33 @@ def chartbuilder(topic, subtopic, measure, version, dimension):
         return redirect(
             url_for(
                 "cms.create_chart_original",
-                topic=topic,
-                subtopic=subtopic,
-                measure=measure,
+                topic_uri=topic_uri,
+                subtopic_uri=subtopic_uri,
+                measure_uri=measure_uri,
                 version=version,
-                dimension=dimension,
+                dimension_guid=dimension_guid,
             )
         )
 
     return redirect(
         url_for(
-            "cms.create_chart", topic=topic, subtopic=subtopic, measure=measure, version=version, dimension=dimension
+            "cms.create_chart",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+            dimension_guid=dimension_guid,
         )
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/create-chart")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/create-chart")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def create_chart(topic, subtopic, measure, version, dimension):
+def create_chart(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_dict = dimension_object.to_dict()
@@ -732,13 +817,13 @@ def create_chart(topic, subtopic, measure, version, dimension):
     return render_template("cms/create_chart_2.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/create-chart/advanced")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/create-chart/advanced")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def create_chart_original(topic, subtopic, measure, version, dimension):
+def create_chart_original(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     context = {
@@ -751,13 +836,13 @@ def create_chart_original(topic, subtopic, measure, version, dimension):
     return render_template("cms/create_chart.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/tablebuilder")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/tablebuilder")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def tablebuilder(topic, subtopic, measure, version, dimension):
+def tablebuilder(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_dict = dimension_object.to_dict()
@@ -766,28 +851,33 @@ def tablebuilder(topic, subtopic, measure, version, dimension):
         return redirect(
             url_for(
                 "cms.create_table_original",
-                topic=topic,
-                subtopic=subtopic,
-                measure=measure,
+                topic_uri=topic_uri,
+                subtopic_uri=subtopic_uri,
+                measure_uri=measure_uri,
                 version=version,
-                dimension=dimension,
+                dimension_guid=dimension_guid,
             )
         )
 
     return redirect(
         url_for(
-            "cms.create_table", topic=topic, subtopic=subtopic, measure=measure, version=version, dimension=dimension
+            "cms.create_table",
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
+            version=version,
+            dimension_guid=dimension_guid,
         )
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/create-table/advanced")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/create-table/advanced")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def create_table_original(topic, subtopic, measure, version, dimension):
+def create_table_original(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     context = {
@@ -800,13 +890,13 @@ def create_table_original(topic, subtopic, measure, version, dimension):
     return render_template("cms/create_table.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/create-table")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/create-table")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def create_table(topic, subtopic, measure, version, dimension):
+def create_table(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     topic_page, subtopic_page, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_dict = dimension_object.to_dict()
@@ -822,13 +912,15 @@ def create_table(topic, subtopic, measure, version, dimension):
     return render_template("cms/create_table_2.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/save-chart", methods=["POST"])
+@cms_blueprint.route(
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/save-chart", methods=["POST"]
+)
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def save_chart_to_page(topic, subtopic, measure, version, dimension):
+def save_chart_to_page(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     *_, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     if measure_page.not_editable():
@@ -840,47 +932,49 @@ def save_chart_to_page(topic, subtopic, measure, version, dimension):
 
     dimension_service.update_measure_dimension(dimension_object, chart_json)
 
-    message = 'Updated chart on dimension "{}" of measure "{}"'.format(dimension_object.title, measure)
+    message = 'Updated chart on dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
     current_app.logger.info(message)
     flash(message, "info")
 
     return jsonify({"success": True})
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/delete-chart")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete-chart")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def delete_chart(topic, subtopic, measure, version, dimension):
+def delete_chart(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     *_, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_service.delete_chart(dimension_object)
 
-    message = 'Deleted chart from dimension "{}" of measure "{}"'.format(dimension_object.title, measure)
+    message = 'Deleted chart from dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
     current_app.logger.info(message)
     flash(message, "info")
 
     return redirect(
         url_for(
             "cms.edit_dimension",
-            topic=topic,
-            subtopic=subtopic,
-            measure=measure,
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
             version=version,
-            dimension=dimension_object.guid,
+            dimension_guid=dimension_object.guid,
         )
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/save-table", methods=["POST"])
+@cms_blueprint.route(
+    "/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/save-table", methods=["POST"]
+)
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def save_table_to_page(topic, subtopic, measure, version, dimension):
+def save_table_to_page(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     *_, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     if measure_page.not_editable():
@@ -892,44 +986,44 @@ def save_table_to_page(topic, subtopic, measure, version, dimension):
 
     dimension_service.update_measure_dimension(dimension_object, table_json)
 
-    message = 'Updated table on dimension "{}" of measure "{}"'.format(dimension_object.title, measure)
+    message = 'Updated table on dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
     current_app.logger.info(message)
     flash(message, "info")
 
     return jsonify({"success": True})
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/<dimension>/delete-table")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/<dimension_guid>/delete-table")
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def delete_table(topic, subtopic, measure, version, dimension):
+def delete_table(topic_uri, subtopic_uri, measure_uri, version, dimension_guid):
     *_, measure_page, dimension_object = page_service.get_measure_page_hierarchy(
-        topic, subtopic, measure, version, dimension=dimension
+        topic_uri, subtopic_uri, measure_uri, version, dimension_guid=dimension_guid
     )
 
     dimension_service.delete_table(dimension_object)
 
-    message = 'Deleted table from dimension "{}" of measure "{}"'.format(dimension_object.title, measure)
+    message = 'Deleted table from dimension "{}" of measure "{}"'.format(dimension_object.title, measure_uri)
     current_app.logger.info(message)
     flash(message, "info")
 
     return redirect(
         url_for(
             "cms.edit_dimension",
-            topic=topic,
-            subtopic=subtopic,
-            measure=measure,
+            topic_uri=topic_uri,
+            subtopic_uri=subtopic_uri,
+            measure_uri=measure_uri,
             version=version,
-            dimension=dimension_object.guid,
+            dimension_guid=dimension_object.guid,
         )
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/uploads", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/uploads", methods=["GET"])
 @login_required
-def get_measure_page_uploads(topic, subtopic, measure, version):
-    *_, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def get_measure_page_uploads(topic_uri, subtopic_uri, measure_uri, version):
+    *_, measure_page = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
 
     uploads = upload_service.get_page_uploads(measure_page) or {}
     return json.dumps({"uploads": uploads}), 200
@@ -986,20 +1080,23 @@ def set_dimension_order(topic, subtopic, measure):
         return json.dumps({"status": "INTERNAL SERVER ERROR", "status_code": 500}), 500
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/versions")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/versions")
 @login_required
 @user_has_access
-def list_measure_page_versions(topic, subtopic, measure):
+def list_measure_page_versions(topic_uri, subtopic_uri, measure_uri):
     try:
-        topic_page = page_service.get_page(topic)
-        subtopic_page = page_service.get_page(subtopic)
+        topic_page = page_service.get_page_by_uri_and_type(topic_uri, "topic")
+        subtopic_page = page_service.get_page_by_uri_and_type(subtopic_uri, "subtopic")
+
     except PageNotFoundException:
-        current_app.logger.exception("Page id: {} not found".format(measure))
+        current_app.logger.exception("Page id: {} not found".format(measure_uri))
         abort(404)
-    measures = page_service.get_measure_page_versions(subtopic, measure)
+
+    measures = page_service.get_measure_page_versions(subtopic_page.guid, measure_uri)
     measures.sort(reverse=True)
     if not measures:
-        return redirect(url_for("cms.subtopic", topic=topic, subtopic=subtopic))
+        return redirect(url_for("static_site.topic", topic_uri=topic_uri))
+
     measure_title = next(measure for measure in measures if measure.latest).title
     return render_template(
         "cms/measure_page_versions.html",
@@ -1010,46 +1107,64 @@ def list_measure_page_versions(topic, subtopic, measure):
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/delete")
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/delete")
 @login_required
 @user_can(DELETE_MEASURE)
-def delete_measure_page(topic, subtopic, measure, version):
-    topic_page, *_ = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def delete_measure_page(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, *_ = page_service.get_measure_page_hierarchy(topic_uri, subtopic_uri, measure_uri, version)
 
-    page_service.delete_measure_page(measure, version)
+    page_service.delete_measure_page(measure_uri, version)
     if request.referrer.endswith("/versions"):
-        return redirect(url_for("cms.list_measure_page_versions", topic=topic, subtopic=subtopic, measure=measure))
+        return redirect(
+            url_for(
+                "cms.list_measure_page_versions",
+                topic_uri=topic_uri,
+                subtopic_uri=subtopic_uri,
+                measure_uri=measure_uri,
+            )
+        )
     else:
-        return redirect(url_for("static_site.topic", uri=topic_page.uri))
+        return redirect(url_for("static_site.topic", topic_uri=topic_page.uri))
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/new-version", methods=["GET", "POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/new-version", methods=["GET", "POST"])
 @login_required
 @user_can(CREATE_VERSION)
-def new_version(topic, subtopic, measure, version):
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def new_version(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     form = NewVersionForm()
     if form.validate_on_submit():
         version_type = form.data["version_type"]
         try:
-            page = page_service.create_copy(measure, version, version_type, created_by=current_user.email)
+            page = page_service.create_copy(
+                measure_page.guid, measure_page.version, version_type, created_by=current_user.email
+            )
             message = "Added a new %s version %s" % (version_type, page.version)
             flash(message)
             return redirect(
                 url_for(
                     "cms.edit_measure_page",
-                    topic=topic_page.uri,
-                    subtopic=subtopic_page.uri,
-                    measure=page.uri,
+                    topic_uri=topic_page.uri,
+                    subtopic_uri=subtopic_page.uri,
+                    measure_uri=page.uri,
                     version=page.version,
                 )
             )
         except UpdateAlreadyExists as e:
-            message = "Version %s of page %s is already being updated" % (version, measure)
+            message = "Version %s of page %s is already being updated" % (version, measure_uri)
             flash(message, "error")
             return redirect(
-                url_for("cms.new_version", topic=topic, subtopic=subtopic, measure=measure, version=version, form=form)
+                url_for(
+                    "cms.new_version",
+                    topic_uri=topic_uri,
+                    subtopic_uri=subtopic_uri,
+                    measure_uri=measure_uri,
+                    version=version,
+                    form=form,
+                )
             )
 
     return render_template(
@@ -1057,19 +1172,23 @@ def new_version(topic, subtopic, measure, version):
     )
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/copy", methods=["POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/copy", methods=["POST"])
 @login_required
 @user_can(COPY_MEASURE)
-def copy_measure_page(topic, subtopic, measure, version):
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+def copy_measure_page(topic_uri, subtopic_uri, measure_uri, version):
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
-    copied_page = page_service.create_copy(measure, version, version_type="copy", created_by=current_user.email)
+    copied_page = page_service.create_copy(
+        measure_page.guid, measure_page.version, version_type="copy", created_by=current_user.email
+    )
     return redirect(
         url_for(
             "cms.edit_measure_page",
-            topic=topic_page.uri,
-            subtopic=subtopic_page.uri,
-            measure=copied_page.uri,
+            topic_uri=topic_page.uri,
+            subtopic_uri=subtopic_page.uri,
+            measure_uri=copied_page.uri,
             version=copied_page.version,
         )
     )

--- a/application/cms_autosave/views.py
+++ b/application/cms_autosave/views.py
@@ -63,9 +63,9 @@ def update_measure_page(topic, subtopic, measure, version):
 
             url = url_for(
                 "cms.edit_and_preview_measure_page",
-                topic=topic_page.guid,
-                subtopic=subtopic_page.guid,
-                measure=measure_page.guid,
+                topic=topic_page.uri,
+                subtopic=subtopic_page.uri,
+                measure=measure_page.uri,
                 version=measure_page.version,
             )
             return redirect(url)

--- a/application/cms_autosave/views.py
+++ b/application/cms_autosave/views.py
@@ -11,13 +11,15 @@ from application.cms_autosave.forms import MeasurePageAutosaveForm
 from application.utils import user_has_access, user_can
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/edit_and_preview", methods=["GET"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/edit_and_preview", methods=["GET"])
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def edit_and_preview_measure_page(topic, subtopic, measure, version):
+def edit_and_preview_measure_page(topic_uri, subtopic_uri, measure_uri, version):
 
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     form = MeasurePageAutosaveForm(
         obj=measure_page,
@@ -37,13 +39,15 @@ def edit_and_preview_measure_page(topic, subtopic, measure, version):
     return render_template("cms_autosave/edit_and_preview_measure.html", **context)
 
 
-@cms_blueprint.route("/<topic>/<subtopic>/<measure>/<version>/edit_and_preview", methods=["POST"])
+@cms_blueprint.route("/<topic_uri>/<subtopic_uri>/<measure_uri>/<version>/edit_and_preview", methods=["POST"])
 @login_required
 @user_has_access
 @user_can(UPDATE_MEASURE)
-def update_measure_page(topic, subtopic, measure, version):
+def update_measure_page(topic_uri, subtopic_uri, measure_uri, version):
 
-    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(topic, subtopic, measure, version)
+    topic_page, subtopic_page, measure_page = page_service.get_measure_page_hierarchy(
+        topic_uri, subtopic_uri, measure_uri, version
+    )
 
     form = MeasurePageAutosaveForm(
         obj=measure_page,
@@ -63,9 +67,9 @@ def update_measure_page(topic, subtopic, measure, version):
 
             url = url_for(
                 "cms.edit_and_preview_measure_page",
-                topic=topic_page.uri,
-                subtopic=subtopic_page.uri,
-                measure=measure_page.uri,
+                topic_uri=topic_page.uri,
+                subtopic_uri=subtopic_page.uri,
+                measure_uri=measure_page.uri,
                 version=measure_page.version,
             )
             return redirect(url)

--- a/application/dashboard/data_helpers.py
+++ b/application/dashboard/data_helpers.py
@@ -182,9 +182,9 @@ def get_ethnic_group_by_uri_dashboard_data(value_uri):
                     "position": d["page_position"],
                     "url": url_for(
                         "static_site.measure_page",
-                        topic=subtopic["topic_uri"],
-                        subtopic=subtopic["uri"],
-                        measure=d["page_uri"],
+                        topic_uri=subtopic["topic_uri"],
+                        subtopic_uri=subtopic["uri"],
+                        measure_uri=d["page_uri"],
                         version="latest",
                     ),
                 }
@@ -316,9 +316,9 @@ def get_ethnicity_categorisation_by_id_dashboard_data(categorisation_id):
                     "position": d["page_position"],
                     "url": url_for(
                         "static_site.measure_page",
-                        topic=subtopic["topic_uri"],
-                        subtopic=subtopic["uri"],
-                        measure=d["page_uri"],
+                        topic_uri=subtopic["topic_uri"],
+                        subtopic_uri=subtopic["uri"],
+                        measure_uri=d["page_uri"],
                         version="latest",
                     ),
                 }
@@ -404,9 +404,9 @@ def get_geographic_breakdown_by_slug_dashboard_data(slug):
                     "title": measure.page_title,
                     "url": url_for(
                         "static_site.measure_page",
-                        topic=page.parent.uri,
-                        subtopic=page.uri,
-                        measure=measure.page_uri,
+                        topic_uri=page.parent.uri,
+                        subtopic_uri=page.uri,
+                        measure_uri=measure.page_uri,
                         version="latest",
                     ),
                 }

--- a/application/review/views.py
+++ b/application/review/views.py
@@ -22,10 +22,8 @@ def review_page(review_token):
 
         return render_template(
             "static_site/measure.html",
-            topic=page.parent.parent.uri,
-            topic_guid=page.parent.parent.guid,
-            subtopic=page.parent.uri,
-            subtopic_guid=page.parent.guid,
+            topic_uri=page.parent.parent.uri,
+            subtopic_uri=page.parent.uri,
             measure_page=page,
             dimensions=dimensions,
             preview=True,

--- a/application/templates/_shared/_header.html
+++ b/application/templates/_shared/_header.html
@@ -20,29 +20,29 @@
               <li>
                 {% if measure_page.latest_version() %}
                     <a href="{{ url_for('cms.edit_measure_page',
-                 topic=topic_guid,
-                 subtopic=subtopic_guid,
-                 measure=measure_page.guid,
+                 topic_uri=topic_uri,
+                 subtopic_uri=subtopic_uri,
+                 measure_uri=measure_page.uri,
                  version=measure_page.version) }}">Edit</a>
                 {% else %}
                     <a href="{{ url_for('cms.list_measure_page_versions',
-                        topic=topic_guid,
-                        subtopic=subtopic_guid,
-                        measure=measure_page.guid) }}">Edit</a>
+                        topic_uri=topic_uri,
+                        subtopic_uri=subtopic_uri,
+                        measure_uri=measure_page.uri) }}">Edit</a>
                 {% endif %}
               </li>
                 <li>
                 {% if measure_page.latest_version() %}
                     <a href="{{ url_for('static_site.measure_page_markdown',
-                 topic=topic,
-                 subtopic=subtopic,
-                 measure=measure_page.uri,
+                 topic_uri=topic_uri,
+                 subtopic_uri=subtopic_uri,
+                 measure_uri=measure_page.uri,
                  version=measure_page.version) }}">Export</a>
                 {% else %}
                     <a href="{{ url_for('cms.list_measure_page_versions',
-                        topic=topic_guid,
-                        subtopic=subtopic_guid,
-                        measure=measure_page.guid) }}">Export</a>
+                        topic_uri=topic_uri,
+                        subtopic_uri=subtopic_uri,
+                        measure_uri=measure_page.uri) }}">Export</a>
                 {% endif %}
               </li>
             {% endif %}

--- a/application/templates/admin/share_page.html
+++ b/application/templates/admin/share_page.html
@@ -3,9 +3,9 @@
     <tr>
         <td>
             <a href="{{ url_for('static_site.measure_page',
-                       topic=page.parent.parent.uri,
-                       subtopic=page.parent.uri,
-                       measure=page.uri,
+                       topic_uri=page.parent.parent.uri,
+                       subtopic_uri=page.parent.uri,
+                       measure_uri=page.uri,
                        version='latest') }}">{{ page.title }}</a>
         </td>
         <td>

--- a/application/templates/cms/_measures_with_version_history.html
+++ b/application/templates/cms/_measures_with_version_history.html
@@ -25,13 +25,13 @@
           {% if shared_with %}
             <tr data-guid="{{ measure.guid }}" data-subtopic="{{ subtopic.guid }}">
                 <td>
-                    <a href="{{ url_for('static_site.measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                    <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                       {{ measure.title }}
                     </a>
                 </td>
                 {%  if measure.number_of_versions() > 1 %}
                 <td>
-                    <a href="{{ url_for('cms.list_measure_page_versions', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri) }}">
+                    <a href="{{ url_for('cms.list_measure_page_versions', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri) }}">
                         {{ measure.number_of_versions() | format_versions | safe }}
                     </a>
                 </td>

--- a/application/templates/cms/_measures_with_version_history.html
+++ b/application/templates/cms/_measures_with_version_history.html
@@ -31,7 +31,7 @@
                 </td>
                 {%  if measure.number_of_versions() > 1 %}
                 <td>
-                    <a href="{{ url_for('cms.list_measure_page_versions', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid) }}">
+                    <a href="{{ url_for('cms.list_measure_page_versions', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri) }}">
                         {{ measure.number_of_versions() | format_versions | safe }}
                     </a>
                 </td>

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -6,8 +6,8 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -283,7 +283,7 @@
         var data = null;
         function back(evt) {
             console.log("back");
-            window.location.replace("{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}")
+            window.location.replace("{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}")
         }
 
 
@@ -685,7 +685,7 @@
             if (chartObject) {
                 $.ajax({
                     type: "POST",
-                    url: "{{ url_for('cms.save_chart_to_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}",
+                    url: "{{ url_for('cms.save_chart_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}",
                     dataType: 'json',
                     data: JSON.stringify({'chartObject': chartObject, 'source': src, 'chartBuilderVersion': 1}),
                     contentType: 'application/json',

--- a/application/templates/cms/create_chart.html
+++ b/application/templates/cms/create_chart.html
@@ -5,9 +5,9 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -283,7 +283,7 @@
         var data = null;
         function back(evt) {
             console.log("back");
-            window.location.replace("{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}")
+            window.location.replace("{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}")
         }
 
 
@@ -685,7 +685,7 @@
             if (chartObject) {
                 $.ajax({
                     type: "POST",
-                    url: "{{ url_for('cms.save_chart_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}",
+                    url: "{{ url_for('cms.save_chart_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}",
                     dataType: 'json',
                     data: JSON.stringify({'chartObject': chartObject, 'source': src, 'chartBuilderVersion': 1}),
                     contentType: 'application/json',

--- a/application/templates/cms/create_chart_2.html
+++ b/application/templates/cms/create_chart_2.html
@@ -4,9 +4,9 @@
 {% set form_disabled = measure.status != 'DRAFT' %}
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -22,8 +22,8 @@
     {% endif %}
     
     var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-    var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}";
-    var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}";
+    var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}";
+    var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}";
 </script>
 {% endblock %}
 

--- a/application/templates/cms/create_chart_2.html
+++ b/application/templates/cms/create_chart_2.html
@@ -5,8 +5,8 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -22,8 +22,8 @@
     {% endif %}
     
     var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-    var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}";
-    var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}";
+    var url_save_chart_to_page = "{{ url_for('cms.save_chart_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}";
+    var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}";
 </script>
 {% endblock %}
 

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -8,7 +8,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -25,7 +25,7 @@
     <div class="grid-row">
         <div class="column-two-thirds">
         {% block measure_form %}
-            <form method="POST" action="{{ url_for('cms.create_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version )}}">
+            <form method="POST" action="{{ url_for('cms.create_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version )}}">
                 {{ form.csrf_token }}
                 {% block fields %}
 

--- a/application/templates/cms/create_dimension.html
+++ b/application/templates/cms/create_dimension.html
@@ -7,8 +7,8 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -25,7 +25,7 @@
     <div class="grid-row">
         <div class="column-two-thirds">
         {% block measure_form %}
-            <form method="POST" action="{{ url_for('cms.create_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version )}}">
+            <form method="POST" action="{{ url_for('cms.create_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version )}}">
                 {{ form.csrf_token }}
                 {% block fields %}
 

--- a/application/templates/cms/create_new_version.html
+++ b/application/templates/cms/create_new_version.html
@@ -4,8 +4,8 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -21,12 +21,12 @@
     <div class="grid-row">
         <div class="column-two-thirds new-version">
             <p>Current version: <b>{{ measure.version }}</b>
-                <a href="{{ url_for('static_site.measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                     View page
                 </a>
             </p>
             <form method="POST"
-                  action="{{ url_for('cms.new_version', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                  action="{{ url_for('cms.new_version', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                 <div class="version-type">New version type:</div>
                 {% for version in form.version_type %}
                     <div class="input-radio">

--- a/application/templates/cms/create_new_version.html
+++ b/application/templates/cms/create_new_version.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -26,7 +26,7 @@
                 </a>
             </p>
             <form method="POST"
-                  action="{{ url_for('cms.new_version', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                  action="{{ url_for('cms.new_version', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                 <div class="version-type">New version type:</div>
                 {% for version in form.version_type %}
                     <div class="input-radio">

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -5,8 +5,8 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -159,7 +159,7 @@
         data = null;
 
         function back(evt) {
-            window.location.replace("{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}")
+            window.location.replace("{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}")
         }
 
         function uniqueDataInColumn(data, index) {
@@ -446,7 +446,7 @@
         function postTableObject(tableObject, src) {
             $.ajax({
                 type: "POST",
-                url: "{{ url_for('cms.save_table_to_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}",
+                url: "{{ url_for('cms.save_table_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}",
                 dataType: 'json',
                 data: JSON.stringify({'tableObject': tableObject, 'source': src}),
                 contentType: 'application/json',

--- a/application/templates/cms/create_table.html
+++ b/application/templates/cms/create_table.html
@@ -4,9 +4,9 @@
 {% set form_disabled = measure.status != 'DRAFT' %}
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -159,7 +159,7 @@
         data = null;
 
         function back(evt) {
-            window.location.replace("{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}")
+            window.location.replace("{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}")
         }
 
         function uniqueDataInColumn(data, index) {
@@ -446,7 +446,7 @@
         function postTableObject(tableObject, src) {
             $.ajax({
                 type: "POST",
-                url: "{{ url_for('cms.save_table_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}",
+                url: "{{ url_for('cms.save_table_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}",
                 dataType: 'json',
                 data: JSON.stringify({'tableObject': tableObject, 'source': src}),
                 contentType: 'application/json',

--- a/application/templates/cms/create_table_2.html
+++ b/application/templates/cms/create_table_2.html
@@ -4,9 +4,9 @@
 {% set form_disabled = measure.status != 'DRAFT' %}
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -21,8 +21,8 @@
   var settings = {};
   {% endif %}
   var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-  var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}";
-  var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}";
+  var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}";
+  var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}";
 </script>
 {% endblock %}
 

--- a/application/templates/cms/create_table_2.html
+++ b/application/templates/cms/create_table_2.html
@@ -5,8 +5,8 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
-    {"url": url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid), "text": dimension.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid), "text": dimension.title},
   ]
 %}
 
@@ -21,8 +21,8 @@
   var settings = {};
   {% endif %}
   var url_get_classifications = "{{ url_for('cms.get_valid_classifications') }}";
-  var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}";
-  var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}";
+  var url_save_table_to_page = "{{ url_for('cms.save_table_to_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}";
+  var url_edit_dimension = "{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}";
 </script>
 {% endblock %}
 

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -49,7 +49,7 @@
         <div class="column-two-thirds">
             {% block measure_form %}
                 <form method="POST" enctype="multipart/form-data"
-                      action="{{ url_for('cms.create_upload', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version ) }}">
+                      action="{{ url_for('cms.create_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version ) }}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ form.upload.label }}

--- a/application/templates/cms/create_upload.html
+++ b/application/templates/cms/create_upload.html
@@ -4,8 +4,8 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -49,7 +49,7 @@
         <div class="column-two-thirds">
             {% block measure_form %}
                 <form method="POST" enctype="multipart/form-data"
-                      action="{{ url_for('cms.create_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version ) }}">
+                      action="{{ url_for('cms.create_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version ) }}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ form.upload.label }}

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -23,7 +23,7 @@
         <div class="column-two-thirds">
             {% block measure_form %}
                 <form id="dimension_form" method="POST"
-                      action="{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}">
+                      action="{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ super() }}
@@ -45,11 +45,11 @@
                                     <td>Chart</td>
                                     <td>{{ dimension.chart.title.text }}</td>
                                     <td><a id="edit_chart"
-                                           href="{{ url_for('cms.chartbuilder', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.chartbuilder', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}
                                             view{% endif %}</a></td>
                                     <td>{% if 'UPDATE' in  measure.available_actions() %}<a id="delete_chart"
-                                                                                            href="{{ url_for('cms.delete_chart', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">delete</a>{% endif %}
+                                                                                            href="{{ url_for('cms.delete_chart', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">delete</a>{% endif %}
                                     </td>
                                 </tr>
                             {% endif %}
@@ -58,11 +58,11 @@
                                     <td>Table</td>
                                     <td>{{ dimension.table.header }}</td>
                                     <td><a id="edit_table"
-                                           href="{{ url_for('cms.tablebuilder', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.tablebuilder', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}
                                             view{% endif %}</a></td>
                                     <td>{% if 'UPDATE' in  measure.available_actions() %}<a id="delete_table"
-                                                                                            href="{{ url_for('cms.delete_table', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">delete</a>{% endif %}
+                                                                                            href="{{ url_for('cms.delete_table', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">delete</a>{% endif %}
                                     </td>
                                 </tr>
                             {% endif %}
@@ -72,7 +72,7 @@
                                 {% if not dimension.chart or dimension.chart == '""' %}
                                     <li>
                                         <a id="create_chart" class="button"
-                                           href="{{ url_for('cms.chartbuilder', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.chartbuilder', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
                                             Add chart
                                         </a>
                                     </li>
@@ -80,7 +80,7 @@
                                 {% if not dimension.table or dimension.table == '""' %}
                                     <li>
                                         <a id="create_table" class="button"
-                                           href="{{ url_for('cms.create_table', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.create_table', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
                                             Add table
                                         </a>
                                     </li>
@@ -101,13 +101,13 @@
             $('#exit').click(back);
             function back(evt) {
                 evt.preventDefault();
-                window.location.replace("{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}")
+                window.location.replace("{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}")
             }
 
             function submitForm(data) {
                 $.ajax({
                     type: "POST",
-                    url: "{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid )}}",
+                    url: "{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid )}}",
                     data: data,
                     success: function () {
                     }

--- a/application/templates/cms/edit_dimension.html
+++ b/application/templates/cms/edit_dimension.html
@@ -4,8 +4,8 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -23,7 +23,7 @@
         <div class="column-two-thirds">
             {% block measure_form %}
                 <form id="dimension_form" method="POST"
-                      action="{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">
+                      action="{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ super() }}
@@ -45,11 +45,11 @@
                                     <td>Chart</td>
                                     <td>{{ dimension.chart.title.text }}</td>
                                     <td><a id="edit_chart"
-                                           href="{{ url_for('cms.chartbuilder', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.chartbuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}
                                             view{% endif %}</a></td>
                                     <td>{% if 'UPDATE' in  measure.available_actions() %}<a id="delete_chart"
-                                                                                            href="{{ url_for('cms.delete_chart', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">delete</a>{% endif %}
+                                                                                            href="{{ url_for('cms.delete_chart', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">delete</a>{% endif %}
                                     </td>
                                 </tr>
                             {% endif %}
@@ -58,11 +58,11 @@
                                     <td>Table</td>
                                     <td>{{ dimension.table.header }}</td>
                                     <td><a id="edit_table"
-                                           href="{{ url_for('cms.tablebuilder', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.tablebuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
                                         {% if 'UPDATE' in  measure.available_actions() %}edit{% else %}
                                             view{% endif %}</a></td>
                                     <td>{% if 'UPDATE' in  measure.available_actions() %}<a id="delete_table"
-                                                                                            href="{{ url_for('cms.delete_table', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">delete</a>{% endif %}
+                                                                                            href="{{ url_for('cms.delete_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">delete</a>{% endif %}
                                     </td>
                                 </tr>
                             {% endif %}
@@ -72,7 +72,7 @@
                                 {% if not dimension.chart or dimension.chart == '""' %}
                                     <li>
                                         <a id="create_chart" class="button"
-                                           href="{{ url_for('cms.chartbuilder', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.chartbuilder', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
                                             Add chart
                                         </a>
                                     </li>
@@ -80,7 +80,7 @@
                                 {% if not dimension.table or dimension.table == '""' %}
                                     <li>
                                         <a id="create_table" class="button"
-                                           href="{{ url_for('cms.create_table', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid) }}">
+                                           href="{{ url_for('cms.create_table', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid) }}">
                                             Add table
                                         </a>
                                     </li>
@@ -101,13 +101,13 @@
             $('#exit').click(back);
             function back(evt) {
                 evt.preventDefault();
-                window.location.replace("{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}")
+                window.location.replace("{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}")
             }
 
             function submitForm(data) {
                 $.ajax({
                     type: "POST",
-                    url: "{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid )}}",
+                    url: "{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid )}}",
                     data: data,
                     success: function () {
                     }

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -7,7 +7,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
   ]
 %}
 
@@ -58,7 +58,7 @@
 {% block content %}
     {%  set form_disabled = measure.status != 'DRAFT' and not new %}
 
-    <form method="POST" action="{% if new %}{{ url_for('cms.create_measure_page', topic=topic.uri, subtopic=subtopic.uri) }}{% else %}{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}{% endif %}">
+    <form method="POST" action="{% if new %}{{ url_for('cms.create_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri) }}{% else %}{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}{% endif %}">
 
         <!-- version info -->
             <div class="grid-row">
@@ -92,18 +92,18 @@
                             </div>
                             <div class="right">
                                   {% if not new %}
-                                      <a href="{{ url_for('static_site.measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" name="preview">
+                                      <a href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}" name="preview">
                                         {% if measure.status == 'APPROVED' %}View{% else %}Preview this version{% endif %}
                                       </a>
                                   {% endif %}
                             </div>
                             <div class="actions right">
                                 {% if measure.status == 'APPROVED' and measure.latest and current_user.can(CREATE_VERSION) %}
-                                    <a class="button" href="{{ url_for('cms.new_version', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                    <a class="button" href="{{ url_for('cms.new_version', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                         Edit / Create new version
                                     </a>
                                     {% if current_user.can(PUBLISH) %}
-                                        <a class="button warning" href="{{ url_for('cms.unpublish_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                        <a class="button warning" href="{{ url_for('cms.unpublish_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                             Unpublish
                                         </a>
                                     {% endif %}
@@ -115,15 +115,15 @@
 
                                           {% if latest.status == 'DRAFT' or latest.status == 'INTERNAL_REVIEW' or latest.status == 'DEPARTMENT_REVIEW' %}
                                             <a href="{{ url_for('cms.edit_measure_page',
-                                                                topic=topic.uri,
-                                                                subtopic=subtopic.uri,
-                                                                measure=latest.uri,
+                                                                topic_uri=topic.uri,
+                                                                subtopic_uri=subtopic.uri,
+                                                                measure_uri=latest.uri,
                                                                 version=latest.version) }}">Version {{ latest.version }}</a> of this page is in {{ latest.status | format_status | safe }}
                                         {% endif %}
                                         <a href="{{ url_for('cms.list_measure_page_versions',
-                                                            topic=topic.uri,
-                                                            subtopic=subtopic.uri,
-                                                            measure=latest.uri)}}">All versions</a>
+                                                            topic_uri=topic.uri,
+                                                            subtopic_uri=subtopic.uri,
+                                                            measure_uri=latest.uri)}}">All versions</a>
                                     </div>
 
                                 {%  elif measure.status == 'DRAFT' or new %}
@@ -135,7 +135,7 @@
                                 {% if "REJECT" in available_actions %}
                                     <a class="button warning"
                                        id="reject-measure"
-                                       href="{{ url_for('cms.reject_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                       href="{{ url_for('cms.reject_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                         Reject
                                     </a>
                                 {% endif %}
@@ -143,7 +143,7 @@
                                 {% if status == 'REJECTED' or status == 'UNPUBLISHED' %}
                                     <a class="button"
                                         id="send-back-to-draft"
-                                        href="{{ url_for('cms.send_page_to_draft', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                        href="{{ url_for('cms.send_page_to_draft', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                         Send back to draft
                                     </a>
                                 {%  endif %}
@@ -155,17 +155,17 @@
                                         </button>
                                      {% elif next_approval_state == 'INTERNAL_REVIEW' %}
                                         <a class="button neutral" id="send-to-internal-review"
-                                           href="{{ url_for('cms.send_to_review', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                           href="{{ url_for('cms.send_to_review', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                             {{ next_approval_state | format_approve_button | safe }}
                                         </a>
                                     {% elif next_approval_state == 'DEPARTMENT_REVIEW' %}
                                         <a class="button" id="send-to-department-review"
-                                           href="{{ url_for('cms.send_to_review', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                           href="{{ url_for('cms.send_to_review', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                             {{ next_approval_state | format_approve_button | safe }}
                                         </a>
                                     {% elif next_approval_state == 'APPROVED' and current_user.can(PUBLISH) %}
                                         <a class="button" id="send-to-approved"
-                                           href="{{ url_for('cms.publish', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                                           href="{{ url_for('cms.publish', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                                             {{ next_approval_state | format_approve_button | safe }}
                                         </a>
                                     {% endif %}
@@ -266,10 +266,10 @@
                             <tr class="movable" data-dimension-guid="{{ dimension.guid }}">
                                 <td>{{ dimension.title }}</td>
                                 <td>
-                                    <a href="{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">
+                                    <a href="{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">
                                         {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                                 <td>{% if 'UPDATE' in available_actions %}
-                                    <a href="{{ url_for('cms.delete_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">delete</a>{% endif %}
+                                    <a href="{{ url_for('cms.delete_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">delete</a>{% endif %}
                                 </td>
                                 <td class="move-controls">
                                     {% if 'UPDATE' in available_actions %}
@@ -283,7 +283,7 @@
                 {% endif %}
 
                 {% if 'UPDATE' in available_actions %}
-                    <a href="{{ url_for('cms.create_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">Add
+                    <a href="{{ url_for('cms.create_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">Add
                         dimension</a><br/>
                 {% endif %}
 
@@ -419,16 +419,16 @@
                             {% for upload in measure.uploads %}
                                 <tr>
                                     <td>
-                                        <a href="{{ url_for('static_site.measure_page_file_download', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
+                                        <a href="{{ url_for('static_site.measure_page_file_download', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
                                     </td>
                                     <td>{{ upload.title }}</td>
                                     <td>
-                                        <a href="{{ url_for('cms.edit_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, upload=upload.guid ) }}">
+                                        <a href="{{ url_for('cms.edit_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, upload=upload.guid ) }}">
                                             {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a>
                                     </td>
                                     <td>
                                         {% if 'UPDATE' in available_actions %}
-                                            <a href="{{ url_for('cms.delete_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, upload=upload.guid ) }}">delete</a>
+                                            <a href="{{ url_for('cms.delete_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, upload=upload.guid ) }}">delete</a>
                                         {% endif %}
                                     </td>
                                 </tr>
@@ -436,7 +436,7 @@
                         </table>
                     {% endif %}
                     {% if 'UPDATE' in available_actions %}
-                        <a href="{{ url_for('cms.create_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">Add
+                        <a href="{{ url_for('cms.create_upload', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">Add
                             download</a><br/>
                     {% endif %}
                     {% if new %}
@@ -461,7 +461,7 @@
     {% if current_user.can(COPY_MEASURE) %}
     <div class="grid-row">
         <div class="column-two-thirds">
-            <form id="measure-action-section__copy_measure_form-{{ measure.guid }}" method="POST" action="{{ url_for('cms.copy_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+            <form id="measure-action-section__copy_measure_form-{{ measure.guid }}" method="POST" action="{{ url_for('cms.copy_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                 <button class="button copy-button" type="submit">Create a copy of this measure</button>
                 {{ form.csrf_token }}
             </form>
@@ -500,7 +500,7 @@
                 $.ajax({
                     type: 'GET',
                     dataType: 'json',
-                    url: "{{ url_for('cms.get_measure_page_uploads', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version)}}",
+                    url: "{{ url_for('cms.get_measure_page_uploads', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version)}}",
                     success: function (page) {
                         var fileListHtml = '';
                         for (i in page.uploads) {

--- a/application/templates/cms/edit_measure_page.html
+++ b/application/templates/cms/edit_measure_page.html
@@ -58,7 +58,7 @@
 {% block content %}
     {%  set form_disabled = measure.status != 'DRAFT' and not new %}
 
-    <form method="POST" action="{% if new %}{{ url_for('cms.create_measure_page', topic=topic.guid, subtopic=subtopic.guid) }}{% else %}{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}{% endif %}">
+    <form method="POST" action="{% if new %}{{ url_for('cms.create_measure_page', topic=topic.uri, subtopic=subtopic.uri) }}{% else %}{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}{% endif %}">
 
         <!-- version info -->
             <div class="grid-row">
@@ -99,11 +99,11 @@
                             </div>
                             <div class="actions right">
                                 {% if measure.status == 'APPROVED' and measure.latest and current_user.can(CREATE_VERSION) %}
-                                    <a class="button" href="{{ url_for('cms.new_version', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                    <a class="button" href="{{ url_for('cms.new_version', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                         Edit / Create new version
                                     </a>
                                     {% if current_user.can(PUBLISH) %}
-                                        <a class="button warning" href="{{ url_for('cms.unpublish_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                        <a class="button warning" href="{{ url_for('cms.unpublish_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                             Unpublish
                                         </a>
                                     {% endif %}
@@ -115,15 +115,15 @@
 
                                           {% if latest.status == 'DRAFT' or latest.status == 'INTERNAL_REVIEW' or latest.status == 'DEPARTMENT_REVIEW' %}
                                             <a href="{{ url_for('cms.edit_measure_page',
-                                                                topic=topic.guid,
-                                                                subtopic=subtopic.guid,
-                                                                measure=latest.guid,
+                                                                topic=topic.uri,
+                                                                subtopic=subtopic.uri,
+                                                                measure=latest.uri,
                                                                 version=latest.version) }}">Version {{ latest.version }}</a> of this page is in {{ latest.status | format_status | safe }}
                                         {% endif %}
                                         <a href="{{ url_for('cms.list_measure_page_versions',
-                                                            topic=topic.guid,
-                                                            subtopic=subtopic.guid,
-                                                            measure=latest.guid)}}">All versions</a>
+                                                            topic=topic.uri,
+                                                            subtopic=subtopic.uri,
+                                                            measure=latest.uri)}}">All versions</a>
                                     </div>
 
                                 {%  elif measure.status == 'DRAFT' or new %}
@@ -135,7 +135,7 @@
                                 {% if "REJECT" in available_actions %}
                                     <a class="button warning"
                                        id="reject-measure"
-                                       href="{{ url_for('cms.reject_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                       href="{{ url_for('cms.reject_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                         Reject
                                     </a>
                                 {% endif %}
@@ -143,7 +143,7 @@
                                 {% if status == 'REJECTED' or status == 'UNPUBLISHED' %}
                                     <a class="button"
                                         id="send-back-to-draft"
-                                        href="{{ url_for('cms.send_page_to_draft', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                        href="{{ url_for('cms.send_page_to_draft', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                         Send back to draft
                                     </a>
                                 {%  endif %}
@@ -155,17 +155,17 @@
                                         </button>
                                      {% elif next_approval_state == 'INTERNAL_REVIEW' %}
                                         <a class="button neutral" id="send-to-internal-review"
-                                           href="{{ url_for('cms.send_to_review', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                           href="{{ url_for('cms.send_to_review', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                             {{ next_approval_state | format_approve_button | safe }}
                                         </a>
                                     {% elif next_approval_state == 'DEPARTMENT_REVIEW' %}
                                         <a class="button" id="send-to-department-review"
-                                           href="{{ url_for('cms.send_to_review', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                           href="{{ url_for('cms.send_to_review', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                             {{ next_approval_state | format_approve_button | safe }}
                                         </a>
                                     {% elif next_approval_state == 'APPROVED' and current_user.can(PUBLISH) %}
                                         <a class="button" id="send-to-approved"
-                                           href="{{ url_for('cms.publish', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                                           href="{{ url_for('cms.publish', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                                             {{ next_approval_state | format_approve_button | safe }}
                                         </a>
                                     {% endif %}
@@ -266,10 +266,10 @@
                             <tr class="movable" data-dimension-guid="{{ dimension.guid }}">
                                 <td>{{ dimension.title }}</td>
                                 <td>
-                                    <a href="{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}">
+                                    <a href="{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">
                                         {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                                 <td>{% if 'UPDATE' in available_actions %}
-                                    <a href="{{ url_for('cms.delete_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}">delete</a>{% endif %}
+                                    <a href="{{ url_for('cms.delete_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">delete</a>{% endif %}
                                 </td>
                                 <td class="move-controls">
                                     {% if 'UPDATE' in available_actions %}
@@ -283,7 +283,7 @@
                 {% endif %}
 
                 {% if 'UPDATE' in available_actions %}
-                    <a href="{{ url_for('cms.create_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">Add
+                    <a href="{{ url_for('cms.create_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">Add
                         dimension</a><br/>
                 {% endif %}
 
@@ -419,16 +419,16 @@
                             {% for upload in measure.uploads %}
                                 <tr>
                                     <td>
-                                        <a href="{{ url_for('static_site.measure_page_file_download', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
+                                        <a href="{{ url_for('static_site.measure_page_file_download', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
                                     </td>
                                     <td>{{ upload.title }}</td>
                                     <td>
-                                        <a href="{{ url_for('cms.edit_upload', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, upload=upload.guid ) }}">
+                                        <a href="{{ url_for('cms.edit_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, upload=upload.guid ) }}">
                                             {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a>
                                     </td>
                                     <td>
                                         {% if 'UPDATE' in available_actions %}
-                                            <a href="{{ url_for('cms.delete_upload', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, upload=upload.guid ) }}">delete</a>
+                                            <a href="{{ url_for('cms.delete_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, upload=upload.guid ) }}">delete</a>
                                         {% endif %}
                                     </td>
                                 </tr>
@@ -436,7 +436,7 @@
                         </table>
                     {% endif %}
                     {% if 'UPDATE' in available_actions %}
-                        <a href="{{ url_for('cms.create_upload', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">Add
+                        <a href="{{ url_for('cms.create_upload', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">Add
                             download</a><br/>
                     {% endif %}
                     {% if new %}
@@ -461,7 +461,7 @@
     {% if current_user.can(COPY_MEASURE) %}
     <div class="grid-row">
         <div class="column-two-thirds">
-            <form id="measure-action-section__copy_measure_form-{{ measure.guid }}" method="POST" action="{{ url_for('cms.copy_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+            <form id="measure-action-section__copy_measure_form-{{ measure.guid }}" method="POST" action="{{ url_for('cms.copy_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                 <button class="button copy-button" type="submit">Create a copy of this measure</button>
                 {{ form.csrf_token }}
             </form>
@@ -500,13 +500,13 @@
                 $.ajax({
                     type: 'GET',
                     dataType: 'json',
-                    url: "{{ url_for('cms.get_measure_page_uploads', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version)}}",
+                    url: "{{ url_for('cms.get_measure_page_uploads', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version)}}",
                     success: function (page) {
                         var fileListHtml = '';
                         for (i in page.uploads) {
                             fileListHtml = fileListHtml + '<tr>' +
                                 '<td>' + page.uploads[i] + '</td>' +
-                                '<td><a href="/cms/{{ topic.guid }}/{{ subtopic.guid }}/{{ measure.guid }}/{{ measure.version }}/uploads/' + page.uploads[i] + '/delete">Delete</a></td>' +
+                                '<td><a href="/cms/{{ topic.uri }}/{{ subtopic.uri }}/{{ measure.uri }}/{{ measure.version }}/uploads/' + page.uploads[i] + '/delete">Delete</a></td>' +
                                 '</tr>';
                         }
                         $('#fileList').html(fileListHtml);
@@ -544,9 +544,9 @@
             });
             $.ajax({
                 type: 'POST',
-                url: "{{ url_for('cms.set_dimension_order', topic=topic.guid,
-                                                                subtopic=subtopic.guid,
-                                                                measure=measure.guid) }}",
+                url: "{{ url_for('cms.set_dimension_order', topic=topic.uri,
+                                                                subtopic=subtopic.uri,
+                                                                measure=measure.uri) }}",
                 dataType: 'json',
                 contentType: 'application/json',
                 data: JSON.stringify({"dimensions": dimensions}),

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -4,8 +4,8 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
+    {"url": url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -42,10 +42,10 @@
             {% block measure_form %}
                 <p>
                     Uploaded file:
-                    <a href="{{ url_for('static_site.measure_page_file_download', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
+                    <a href="{{ url_for('static_site.measure_page_file_download', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
                 </p>
                 <p>To replace this file choose another file below</p>
-                <form method="POST" enctype="multipart/form-data" action="{{ url_for('cms.edit_upload',topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, upload=upload.guid, version=measure.version)}}">
+                <form method="POST" enctype="multipart/form-data" action="{{ url_for('cms.edit_upload',topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, upload=upload.guid, version=measure.version)}}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ form.upload.label }}
@@ -93,7 +93,7 @@
         $('#exit').click(back);
         function back(evt) {
             evt.preventDefault();
-            window.location.replace("{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}")
+            window.location.replace("{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}")
         }
 </script>
 {% endblock %}

--- a/application/templates/cms/edit_upload.html
+++ b/application/templates/cms/edit_upload.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
-    {"url": url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version), "text": measure.title},
+    {"url": url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version), "text": measure.title},
   ]
 %}
 
@@ -42,10 +42,10 @@
             {% block measure_form %}
                 <p>
                     Uploaded file:
-                    <a href="{{ url_for('static_site.measure_page_file_download', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
+                    <a href="{{ url_for('static_site.measure_page_file_download', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, filename=upload.file_name) }}">{{ upload.file_name }}</a>
                 </p>
                 <p>To replace this file choose another file below</p>
-                <form method="POST" enctype="multipart/form-data" action="{{ url_for('cms.edit_upload',topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, upload=upload.guid, version=measure.version)}}">
+                <form method="POST" enctype="multipart/form-data" action="{{ url_for('cms.edit_upload',topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, upload=upload.guid, version=measure.version)}}">
                     {{ form.csrf_token }}
                     {% block fields %}
                         {{ form.upload.label }}
@@ -93,7 +93,7 @@
         $('#exit').click(back);
         function back(evt) {
             evt.preventDefault();
-            window.location.replace("{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}")
+            window.location.replace("{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}")
         }
 </script>
 {% endblock %}

--- a/application/templates/cms/measure_actions.html
+++ b/application/templates/cms/measure_actions.html
@@ -3,7 +3,7 @@
         <div class="measure-action-section__main" id='measure-action-section-{{ measure.guid }}'>
             <div style="">
                 {% if measure.status == 'DRAFT' %}
-                    <a href="{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}" id="measure-action-section__edit_button-{{ measure.guid }}">Edit</a>
+                    <a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" id="measure-action-section__edit_button-{{ measure.guid }}">Edit</a>
                     {% if include_delete %}
                         <button class="link" id="measure-action-section__delete_button-{{ measure.guid }}"
                                 onclick="showDeleteForm('{{ measure.guid }}')">
@@ -12,9 +12,9 @@
                     {% endif %}
                 {% else %}
                     {% if measure.latest and measure.status == 'APPROVED' and current_user.can(CREATE_VERSION) %}
-                        <a href="{{ url_for('cms.new_version', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}" id="measure-action-section__create_new_link-{{ measure.guid }}">Create&nbsp;new&nbsp;version</a>
+                        <a href="{{ url_for('cms.new_version', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" id="measure-action-section__create_new_link-{{ measure.guid }}">Create&nbsp;new&nbsp;version</a>
                     {%  else %}
-                        <a href="{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}" id="measure-action-section__view_form_link-{{ measure.guid }}">View&nbsp;form</a>
+                        <a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" id="measure-action-section__view_form_link-{{ measure.guid }}">View&nbsp;form</a>
                     {% endif %}
                 {% endif %}
             </div>
@@ -22,7 +22,7 @@
         {% if measure.status == 'DRAFT' and include_delete %}
             <div id="measure-action-section__delete-{{ measure.guid }}" style="display:none">
                 <form name="measure-action-section__delete-{{ measure.guid }}"
-                      action="{{ url_for('cms.delete_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}"
+                      action="{{ url_for('cms.delete_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}"
                       onsubmit="return submitDeleteForm('{{ measure.guid }}')">
                     <div class="delete_version" id='delete-version-{{ measure.guid }}'>
                         <div class="multiple-choice" style="display:block">

--- a/application/templates/cms/measure_actions.html
+++ b/application/templates/cms/measure_actions.html
@@ -3,7 +3,7 @@
         <div class="measure-action-section__main" id='measure-action-section-{{ measure.guid }}'>
             <div style="">
                 {% if measure.status == 'DRAFT' %}
-                    <a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" id="measure-action-section__edit_button-{{ measure.guid }}">Edit</a>
+                    <a href="{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}" id="measure-action-section__edit_button-{{ measure.guid }}">Edit</a>
                     {% if include_delete %}
                         <button class="link" id="measure-action-section__delete_button-{{ measure.guid }}"
                                 onclick="showDeleteForm('{{ measure.guid }}')">
@@ -12,9 +12,9 @@
                     {% endif %}
                 {% else %}
                     {% if measure.latest and measure.status == 'APPROVED' and current_user.can(CREATE_VERSION) %}
-                        <a href="{{ url_for('cms.new_version', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" id="measure-action-section__create_new_link-{{ measure.guid }}">Create&nbsp;new&nbsp;version</a>
+                        <a href="{{ url_for('cms.new_version', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}" id="measure-action-section__create_new_link-{{ measure.guid }}">Create&nbsp;new&nbsp;version</a>
                     {%  else %}
-                        <a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}" id="measure-action-section__view_form_link-{{ measure.guid }}">View&nbsp;form</a>
+                        <a href="{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}" id="measure-action-section__view_form_link-{{ measure.guid }}">View&nbsp;form</a>
                     {% endif %}
                 {% endif %}
             </div>
@@ -22,7 +22,7 @@
         {% if measure.status == 'DRAFT' and include_delete %}
             <div id="measure-action-section__delete-{{ measure.guid }}" style="display:none">
                 <form name="measure-action-section__delete-{{ measure.guid }}"
-                      action="{{ url_for('cms.delete_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}"
+                      action="{{ url_for('cms.delete_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}"
                       onsubmit="return submitDeleteForm('{{ measure.guid }}')">
                     <div class="delete_version" id='delete-version-{{ measure.guid }}'>
                         <div class="multiple-choice" style="display:block">

--- a/application/templates/cms/measure_page_versions.html
+++ b/application/templates/cms/measure_page_versions.html
@@ -5,7 +5,7 @@
 {% set breadcrumbs =
   [
     {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures"},
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
   ]
 %}
 
@@ -50,7 +50,7 @@
                 {% for measure in measures %}
                     <tr>
                         <td>
-                          <a class="measure-link" href="{{ url_for('static_site.measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                          <a class="measure-link" href="{{ url_for('static_site.measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                             {{ measure.version }}
                           </a>
                         </td>

--- a/application/templates/cms_autosave/_dimensions.html
+++ b/application/templates/cms_autosave/_dimensions.html
@@ -8,10 +8,10 @@
                         <tr class="movable" data-dimension-guid="{{ dimension.guid }}">
                             <td>{{ dimension.title }}</td>
                             <td>
-                                <a href="{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">
+                                <a href="{{ url_for('cms.edit_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">
                                     {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                             <td>{% if 'UPDATE' in available_actions %}
-                                <a href="{{ url_for('cms.delete_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">delete</a>{% endif %}
+                                <a href="{{ url_for('cms.delete_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version, dimension_guid=dimension.guid ) }}">delete</a>{% endif %}
                             </td>
                             <td class="move-controls">
                                 {% if 'UPDATE' in available_actions %}
@@ -25,7 +25,7 @@
             {% endif %}
 
             {% if 'UPDATE' in available_actions %}
-                <a href="{{ url_for('cms.create_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">Add
+                <a href="{{ url_for('cms.create_dimension', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">Add
                     dimension</a><br/>
             {% endif %}
 

--- a/application/templates/cms_autosave/_dimensions.html
+++ b/application/templates/cms_autosave/_dimensions.html
@@ -8,10 +8,10 @@
                         <tr class="movable" data-dimension-guid="{{ dimension.guid }}">
                             <td>{{ dimension.title }}</td>
                             <td>
-                                <a href="{{ url_for('cms.edit_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}">
+                                <a href="{{ url_for('cms.edit_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">
                                     {% if 'UPDATE' in available_actions %}edit{% else %}view{% endif %}</a></td>
                             <td>{% if 'UPDATE' in available_actions %}
-                                <a href="{{ url_for('cms.delete_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version, dimension=dimension.guid ) }}">delete</a>{% endif %}
+                                <a href="{{ url_for('cms.delete_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version, dimension=dimension.guid ) }}">delete</a>{% endif %}
                             </td>
                             <td class="move-controls">
                                 {% if 'UPDATE' in available_actions %}
@@ -25,7 +25,7 @@
             {% endif %}
 
             {% if 'UPDATE' in available_actions %}
-                <a href="{{ url_for('cms.create_dimension', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">Add
+                <a href="{{ url_for('cms.create_dimension', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">Add
                     dimension</a><br/>
             {% endif %}
 

--- a/application/templates/cms_autosave/edit_and_preview_measure.html
+++ b/application/templates/cms_autosave/edit_and_preview_measure.html
@@ -9,9 +9,9 @@
 {% block bodyEnd %}
   {{ super() }}
     <script>
-        var set_dimension_order_post_url = "{{ url_for('cms.set_dimension_order', topic=topic.guid,
-                                                            subtopic=subtopic.guid,
-                                                            measure=measure.guid) }}"
+        var set_dimension_order_post_url = "{{ url_for('cms.set_dimension_order', topic=topic.uri,
+                                                            subtopic=subtopic.uri,
+                                                            measure=measure.uri) }}"
     </script>
     <script type="text/javascript" src="{{ url_for('static', filename='javascripts/') }}{{ 'cms_autosave.js' | version_filter }}"></script>
 {% endblock %}
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block content %}
-    <form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+    <form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
         <div class="rd_cms_autocomplete">
             {% include 'cms_autosave/_measure_title.html' %}
             {% include 'cms_autosave/_public_metadata.html' %}

--- a/application/templates/cms_autosave/edit_and_preview_measure.html
+++ b/application/templates/cms_autosave/edit_and_preview_measure.html
@@ -2,7 +2,7 @@
 
 {% set breadcrumbs =
   [
-    {"url": url_for('static_site.topic', uri=topic.uri), "text": topic.title},
+    {"url": url_for('static_site.topic', topic_uri=topic.uri), "text": topic.title},
   ]
 %}
 
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block content %}
-    <form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+    <form method="POST" action="{{ url_for('cms.edit_and_preview_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
         <div class="rd_cms_autocomplete">
             {% include 'cms_autosave/_measure_title.html' %}
             {% include 'cms_autosave/_public_metadata.html' %}

--- a/application/templates/dashboards/measures.html
+++ b/application/templates/dashboards/measures.html
@@ -30,9 +30,9 @@
                     {% for subtopic in topic.children %}
                         {% for measure in subtopic.children %}
                             <tr>
-                                <td><a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">{{ measure.title }}</a></td>
+                                <td><a href="{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">{{ measure.title }}</a></td>
                                 <td>{{ measure.internal_reference }}</td>
-                                <td><a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">{{ measure.version }}</a></td>
+                                <td><a href="{{ url_for('cms.edit_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">{{ measure.version }}</a></td>
                                 <td>{{ topic.title}}</td>
                                 <td>{{ subtopic.title }}</td>
                                 <td>{{ measure.status }}</td>

--- a/application/templates/dashboards/measures.html
+++ b/application/templates/dashboards/measures.html
@@ -30,9 +30,9 @@
                     {% for subtopic in topic.children %}
                         {% for measure in subtopic.children %}
                             <tr>
-                                <td><a href="{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">{{ measure.title }}</a></td>
+                                <td><a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">{{ measure.title }}</a></td>
                                 <td>{{ measure.internal_reference }}</td>
-                                <td><a href="{{ url_for('cms.edit_measure_page', topic=topic.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">{{ measure.version }}</a></td>
+                                <td><a href="{{ url_for('cms.edit_measure_page', topic=topic.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">{{ measure.version }}</a></td>
                                 <td>{{ topic.title}}</td>
                                 <td>{{ subtopic.title }}</td>
                                 <td>{{ measure.status }}</td>

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -71,9 +71,9 @@
                               <ul>
                                 {% for page in  week['publications'] %}
                                     <li><a href="{{ url_for('static_site.measure_page',
-                                                            topic=page.parent.parent.uri,
-                                                            subtopic=page.parent.uri,
-                                                            measure=page.uri,
+                                                            topic_uri=page.parent.parent.uri,
+                                                            subtopic_uri=page.parent.uri,
+                                                            measure_uri=page.uri,
                                                             version='latest') }}">{{ page.title }}</a>
                                         <span class="source">{{ page.department_source.name }}</span>{{ page.publication_date | format_friendly_short_date}}</li>
                                 {% endfor %}
@@ -84,9 +84,9 @@
                               <ul>
                                 {% for page in week['major_updates'] %}
                                     <li><a href="{{ url_for('static_site.measure_page',
-                                                            topic=page.parent.parent.uri,
-                                                            subtopic=page.parent.uri,
-                                                            measure=page.uri,
+                                                            topic_uri=page.parent.parent.uri,
+                                                            subtopic_uri=page.parent.uri,
+                                                            measure_uri=page.uri,
                                                             version='latest') }}">{{ page.title }}</a>
                                         <span class="source">{{ page.department_source.name }}</span>{{ page.publication_date | format_friendly_short_date}}</li>
                                 {% endfor %}

--- a/application/templates/dashboards/whats_new.html
+++ b/application/templates/dashboards/whats_new.html
@@ -26,9 +26,9 @@
           {% for page in pages %}
             <li><a href="{{ url_for(
               'static_site.measure_page',
-              topic=page.parent.parent.uri,
-              subtopic=page.parent.uri,
-              measure=page.uri,
+              topic_uri=page.parent.parent.uri,
+              subtopic_uri=page.parent.uri,
+              measure_uri=page.uri,
               version='latest'
             ) }}">
 

--- a/application/templates/static_site/_measures_with_version_history.html
+++ b/application/templates/static_site/_measures_with_version_history.html
@@ -19,13 +19,13 @@
       {% for measure in measures[subtopic.guid] %}
           <tr>
               <td>
-                  <a href="{{ url_for('cms.edit_measure_page', topic=page.guid, subtopic=subtopic.guid, measure=measure.guid, version=measure.version) }}">
+                  <a href="{{ url_for('cms.edit_measure_page', topic=page.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
                       {{ measure.title }}
                   </a>
               </td>
              {%  if measure.number_of_versions() > 1 %}
                   <td>
-                      <a href="{{ url_for('cms.list_measure_page_versions', topic=page.guid, subtopic=subtopic.guid, measure=measure.guid) }}">
+                      <a href="{{ url_for('cms.list_measure_page_versions', topic=page.uri, subtopic=subtopic.uri, measure=measure.uri) }}">
                           {{ measure.number_of_versions() | format_versions | safe }}
                       </a>
                   </td>
@@ -52,7 +52,7 @@
                 {% if measure.status == 'DRAFT' and measure.version == '1.0' %}
                     <div id="measure-action-section__delete-{{ measure.guid }}" style="display:none">
                       <form name="measure-action-section__delete-{{ measure.guid }}"
-                            action="{{ url_for('cms.delete_measure_page_1_0', topic=page.guid, subtopic=subtopic.guid, measure=measure.guid) }}"
+                            action="{{ url_for('cms.delete_measure_page_1_0', topic=page.uri, subtopic=subtopic.uri, measure=measure.uri) }}"
                             onsubmit="return submitDeleteForm('{{ measure.guid }}')">
                         <div class="delete_version" id='delete-version-{{ measure.guid }}'>
                           <div class="multiple-choice" style="display:block">

--- a/application/templates/static_site/_measures_with_version_history.html
+++ b/application/templates/static_site/_measures_with_version_history.html
@@ -19,13 +19,13 @@
       {% for measure in measures[subtopic.guid] %}
           <tr>
               <td>
-                  <a href="{{ url_for('cms.edit_measure_page', topic=page.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                  <a href="{{ url_for('cms.edit_measure_page', topic_uri=page.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                       {{ measure.title }}
                   </a>
               </td>
              {%  if measure.number_of_versions() > 1 %}
                   <td>
-                      <a href="{{ url_for('cms.list_measure_page_versions', topic=page.uri, subtopic=subtopic.uri, measure=measure.uri) }}">
+                      <a href="{{ url_for('cms.list_measure_page_versions', topic_uri=page.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri) }}">
                           {{ measure.number_of_versions() | format_versions | safe }}
                       </a>
                   </td>
@@ -37,7 +37,7 @@
               <div class="measure-action-section">
                 <div class="measure-action-section__main" id='measure-action-section-{{ measure.guid }}'>
                     <div style="display:inline-block">
-                      <a id="measure_action__view-{{ measure.guid }}" href="{{ url_for('static_site.measure_page', topic=page.uri, subtopic=subtopic.uri, measure=measure.uri, version=measure.version) }}">
+                      <a id="measure_action__view-{{ measure.guid }}" href="{{ url_for('static_site.measure_page', topic_uri=page.uri, subtopic_uri=subtopic.uri, measure_uri=measure.uri, version=measure.version) }}">
                           {%  if measure.status == 'APPROVED' %}View{%  else  %}Preview{%  endif %}
                       </a>
                     </div>

--- a/application/templates/static_site/_preview.html
+++ b/application/templates/static_site/_preview.html
@@ -10,7 +10,7 @@
             <span><a href="https://www.ethnicity-facts-figures.service.gov.uk">Live website</a></span>
 
             {% if not static_mode and not current_user.is_anonymous and not preview %}
-              <span><a href="{{ url_for('static_site.topic', uri='testing-space') }}">Testing space</a></span>
+              <span><a href="{{ url_for('static_site.topic', topic_uri='testing-space') }}">Testing space</a></span>
 
               {% if current_user.can(MANAGE_USERS) %}
                 <span><a href="{{ url_for('admin.index') }}">Admin</a></span>

--- a/application/templates/static_site/_share.html
+++ b/application/templates/static_site/_share.html
@@ -4,7 +4,7 @@
     <h4>Share this page</h4>
     <div class="share">
 
-      {% set encoded_url = (config.RDU_SITE.rstrip('/') + url_for('static_site.measure_page', topic=topic, subtopic=subtopic, measure=measure_page.uri, version='latest')) | urlencode %}
+      {% set encoded_url = (config.RDU_SITE.rstrip('/') + url_for('static_site.measure_page', topic_uri=topic_uri, subtopic_uri=subtopic_uri, measure_uri=measure_page.uri, version='latest')) | urlencode %}
 
       {% set encoded_title = (measure_page.title | urlencode ) %}
 

--- a/application/templates/static_site/export/measure_export.html
+++ b/application/templates/static_site/export/measure_export.html
@@ -11,9 +11,9 @@
               content="https://www.ethnicity-facts-figures.service.gov.uk/static/images/opengraph-image.png"/>
         <meta itemscope itemprop="mainEntityOfPage" itemType="https://schema.org/WebPage"
               itemid="https://www.ethnicity-facts-figures.service.gov.uk{{ url_for('static_site.measure_page',
-                          topic=topic,
-                          subtopic=subtopic,
-                          measure=measure_page.uri,
+                          topic_uri=topic_uri,
+                          subtopic_uri=subtopic_uri,
+                          measure_uri=measure_page.uri,
                           version=version) }}"/>
 
         <div class="grid-row">

--- a/application/templates/static_site/index.html
+++ b/application/templates/static_site/index.html
@@ -48,7 +48,7 @@
           {% for topic in topic_batch %}
           <div class="column-one-third topic">
               <span class="heading-small">
-                  <a href="{{ url_for('static_site.topic', uri=topic.uri) }}">{{ topic.title }}{% if topic.is_published_measure_or_parent_of == false %} (not published){% endif %}</a>
+                  <a href="{{ url_for('static_site.topic', topic_uri=topic.uri) }}">{{ topic.title }}{% if topic.is_published_measure_or_parent_of == false %} (not published){% endif %}</a>
               </span>
               <p>{{ topic.description }}</p>
           </div>

--- a/application/templates/static_site/measure.html
+++ b/application/templates/static_site/measure.html
@@ -3,7 +3,7 @@
 {% set breadcrumbs = 
   [
     {"url": url_for("static_site.index"), "text": "Ethnicity facts and figures", "event": "breadcrumb-homepage"},
-    {"url": url_for("static_site.topic", uri=topic), "text": measure_page.parent.parent.title, "event": "breadcrumb-" + topic},
+    {"url": url_for("static_site.topic", topic_uri=topic_uri), "text": measure_page.parent.parent.title, "event": "breadcrumb-" + topic_uri},
   ]
   if not preview else
   none
@@ -23,9 +23,9 @@
                   href="/{{ topic }}/{{ subtopic }}/{{ measure_page.uri }}/{{ version }}/data.json">
         {% else %}
             <link rel="alternate" type="application/json" title="{{ measure_page.title }}" href="{{ url_for('static_site.measure_page_json',
-                          topic=topic,
-                          subtopic=subtopic,
-                          measure=measure_page.uri,
+                          topic_uri=topic_uri,
+                          subtopic_uri=subtopic_uri,
+                          measure_uri=measure_page.uri,
                           version=measure_page.version) }}">
         {% endif %}
 
@@ -42,9 +42,9 @@
   {% set version = 'latest' if measure_page.has_no_later_published_versions() else measure_page.version %}
   <meta itemprop="image" content="https://www.ethnicity-facts-figures.service.gov.uk/static/images/opengraph-image.png" />
   <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.ethnicity-facts-figures.service.gov.uk{{ url_for('static_site.measure_page',
-                          topic=topic,
-                          subtopic=subtopic,
-                          measure=measure_page.uri,
+                          topic_uri=topic_uri,
+                          subtopic_uri=subtopic_uri,
+                          measure_uri=measure_page.uri,
                           version=version) }}"/>
   
   <div class="grid-row">
@@ -59,9 +59,9 @@
     <div class="old-edition-notice">
       <h2 class="heading-large">There is a new version of this page</h2>
       <p>View the <a href="{{ url_for('static_site.measure_page',
-                            topic=topic,
-                            subtopic=subtopic,
-                            measure=measure_page.uri,
+                            topic_uri=topic_uri,
+                            subtopic_uri=subtopic_uri,
+                            measure_uri=measure_page.uri,
                             version='latest') }}">latest version</a></p>
     </div>
   {% endif %}
@@ -273,11 +273,11 @@
                                  download="{{ dimension.static_table_file_name }}">Download table data (CSV)</a>
                           {% else %}
                               <a href="{{ url_for('static_site.dimension_file_table_download',
-                                   topic=topic,
-                                   subtopic=subtopic,
-                                   measure=measure_page.guid,
+                                   topic_uri=topic_uri,
+                                   subtopic_uri=subtopic_uri,
+                                   measure_uri=measure_page.uri,
                                    version=measure_page.version,
-                                   dimension=dimension.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.table.header}}">Download table data (CSV)</a>
+                                   dimension_guid=dimension.guid) }}"  data-on="click"  data-event-category="CSV downloaded" data-event-action="Table as spreadsheet" data-event-label="{{dimension.table.header}}">Download table data (CSV)</a>
                           {% endif %}
 
                                                     {% if static_mode %}
@@ -285,11 +285,11 @@
                                  data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.table.header}}">Source data (CSV)</a>
                           {% else %}
                               <a href="{{ url_for('static_site.dimension_file_download',
-                                   topic=topic,
-                                   subtopic=subtopic,
-                                   measure=measure_page.guid,
+                                   topic_uri=topic_uri,
+                                   subtopic_uri=subtopic_uri,
+                                   measure_uri=measure_page.uri,
                                    version=measure_page.version,
-                                   dimension=dimension.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.table.header}}">Source data (CSV)</a>
+                                   dimension_guid=dimension.guid) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Table source data" data-event-label="{{dimension.table.header}}">Source data (CSV)</a>
                           {% endif %}
                       </p>
                     {% endif %}
@@ -473,9 +473,9 @@
                     <a href="/{{ topic }}/{{ subtopic }}/{{ measure_page.uri }}/{{ version }}/downloads/{{ file.file_name}}" download="{{ file.file_name }}">{{ file.file_name }}</a>
                   {%  else %}
                     <a href="{{ url_for('static_site.measure_page_file_download',
-                        topic=topic,
-                        subtopic=subtopic,
-                        measure=measure_page.guid,
+                        topic_uri=topic_uri,
+                        subtopic_uri=subtopic_uri,
+                        measure_uri=measure_page.uri,
                         version=measure_page.version,
                         filename=file.file_name) }}" data-on="click" data-event-category="CSV downloaded" data-event-action="Source data" data-event-label="{{ file.title }}">
                           {{ file.title }}
@@ -496,9 +496,9 @@
                   <a href="/{{ topic }}/{{ subtopic }}/{{ measure_page.uri }}/{{ version }}/data.json">View this page as JSON</a>
               {% else %}
                   <a href="{{ url_for('static_site.measure_page_json',
-                      topic=topic,
-                      subtopic=subtopic,
-                      measure=measure_page.uri,
+                      topic_uri=topic_uri,
+                      subtopic_uri=subtopic_uri,
+                      measure_uri=measure_page.uri,
                       version=measure_page.version) }}">View this page as JSON</a>
               {% endif %}
             {% endif %}
@@ -592,9 +592,9 @@
                 {% for v in versions %}
                     <li>
                         <a href="{{ url_for('static_site.measure_page',
-                            topic=topic,
-                            subtopic=subtopic,
-                            measure=v.uri,
+                            topic_uri=topic_uri,
+                            subtopic_uri=subtopic_uri,
+                            measure_uri=v.uri,
                             version=v.version) }}">{{ v.publication_date|format_friendly_date }}</a>
                     </li>
                 {% endfor %}

--- a/application/templates/static_site/static_pages/ethnicity_in_the_uk.html
+++ b/application/templates/static_site/static_pages/ethnicity_in_the_uk.html
@@ -139,27 +139,27 @@
 
             <ul class="bullets">
               <li>
-                <a href="{{ url_for('static_site.measure_page', topic='british-population', subtopic='national-and-regional-populations', measure='population-of-england-and-wales', version='latest') }}">
+                <a href="{{ url_for('static_site.measure_page', topic_uri='british-population', subtopic_uri='national-and-regional-populations', measure_uri='population-of-england-and-wales', version='latest') }}">
                   population of England and Wales
                 </a>
               </li>
               <li>
-                <a href="{{ url_for('static_site.measure_page', topic='british-population', subtopic='national-and-regional-populations', measure='regional-ethnic-diversity', version='latest') }}">
+                <a href="{{ url_for('static_site.measure_page', topic_uri='british-population', subtopic_uri='national-and-regional-populations', measure_uri='regional-ethnic-diversity', version='latest') }}">
                   region
                 </a>
               </li>
               <li>
-                <a href="{{ url_for('static_site.measure_page', topic='british-population', subtopic='demographics', measure='socioeconomic-status', version='latest') }}">
+                <a href="{{ url_for('static_site.measure_page', topic_uri='british-population', subtopic_uri='demographics', measure_uri='socioeconomic-status', version='latest') }}">
                   economic status
                 </a>
               </li>
               <li>
-                <a href="{{ url_for('static_site.measure_page', topic='british-population', subtopic='demographics', measure='male-and-female-populations', version='latest') }}">
+                <a href="{{ url_for('static_site.measure_page', topic_uri='british-population', subtopic_uri='demographics', measure_uri='male-and-female-populations', version='latest') }}">
                   gender
                 </a>
               </li>
               <li>
-                <a href="{{ url_for('static_site.measure_page', topic='british-population', subtopic='demographics', measure='age-groups', version='latest') }}">
+                <a href="{{ url_for('static_site.measure_page', topic_uri='british-population', subtopic_uri='demographics', measure_uri='age-groups', version='latest') }}">
                   age
                 </a>
               </li>

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -49,9 +49,9 @@
                                                     {% for m in measures[subtopic.guid] %}
                                                         <li>
                                                             <a href="{{ url_for('static_site.measure_page',
-                                                                                topic=topic.uri,
-                                                                                subtopic=subtopic.uri,
-                                                                                measure=m.uri,
+                                                                                topic_uri=topic.uri,
+                                                                                subtopic_uri=subtopic.uri,
+                                                                                measure_uri=m.uri,
                                                                                 version='latest') }}">{{ m.title }}
                                                             </a>
                                                         </li>
@@ -64,7 +64,7 @@
 
                                         {% if not static_mode %}
                                             {% if current_user.can(CREATE_MEASURE) %}
-                                                <p><a href="{{ url_for('cms.create_measure_page', topic=topic.uri, subtopic=subtopic.uri) }}" class="button">Add a measure to {{ subtopic.title }}</a></p>
+                                                <p><a href="{{ url_for('cms.create_measure_page', topic_uri=topic.uri, subtopic_uri=subtopic.uri) }}" class="button">Add a measure to {{ subtopic.title }}</a></p>
                                             {% endif %}
                                         {% endif %}
                                     </div>

--- a/application/templates/static_site/topic.html
+++ b/application/templates/static_site/topic.html
@@ -64,7 +64,7 @@
 
                                         {% if not static_mode %}
                                             {% if current_user.can(CREATE_MEASURE) %}
-                                                <p><a href="{{ url_for('cms.create_measure_page', topic=topic.guid, subtopic=subtopic.guid) }}" class="button">Add a measure to {{ subtopic.title }}</a></p>
+                                                <p><a href="{{ url_for('cms.create_measure_page', topic=topic.uri, subtopic=subtopic.uri) }}" class="button">Add a measure to {{ subtopic.title }}</a></p>
                                             {% endif %}
                                         {% endif %}
                                     </div>

--- a/application/utils.py
+++ b/application/utils.py
@@ -45,7 +45,7 @@ def get_bool(param):
 def user_has_access(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        measure_id = kwargs.get("measure")
+        measure_id = kwargs.get("measure") or kwargs.get("measure_uri")
         if current_user.is_authenticated and measure_id is not None and current_user.can_access(measure_id):
             return f(*args, **kwargs)
         else:

--- a/migrations/versions/2018_10_15_index_page_type_uri.py
+++ b/migrations/versions/2018_10_15_index_page_type_uri.py
@@ -1,0 +1,24 @@
+"""add composite index for page uri and version
+
+Revision ID: 2018_10_15_index_page_type_uri
+Revises: 2018_08_12_tablebuilder_2
+Create Date: 2018-10-15 11:58:37.004443
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "2018_10_15_index_page_type_uri"
+down_revision = "2018_08_12_tablebuilder_2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("ix_page_type_uri", "page", ["page_type", "uri"], unique=False)
+
+
+def downgrade():
+    op.drop_index("ix_page_type_uri", table_name="page")

--- a/scripts/oneoff/find_dimensions_with_transposed_table_cells.py
+++ b/scripts/oneoff/find_dimensions_with_transposed_table_cells.py
@@ -49,8 +49,8 @@ def edit_table_url_from_dimension(dimension, tablebuilder2=False):
     topic_page = subtopic_page.parent
     return url_for(
         "cms.create_table" if tablebuilder2 else "cms.create_table_original",
-        topic=topic_page.guid,
-        subtopic=subtopic_page.guid,
+        topic=topic_page.uri,
+        subtopic=subtopic_page.uri,
         measure=measure_page.guid,
         version=dimension.page_version,
         dimension=dimension.guid,

--- a/scripts/oneoff/find_dimensions_with_transposed_table_cells.py
+++ b/scripts/oneoff/find_dimensions_with_transposed_table_cells.py
@@ -35,9 +35,9 @@ def measure_page_url_from_dimension(dimension):
     topic_page = subtopic_page.parent
     return url_for(
         "static_site.measure_page",
-        topic=topic_page.uri,
-        subtopic=subtopic_page.uri,
-        measure=measure_page.uri,
+        topic_uri=topic_page.uri,
+        subtopic_uri=subtopic_page.uri,
+        measure_uri=measure_page.uri,
         version=dimension.page_version,
         _external=True,
     )
@@ -49,11 +49,11 @@ def edit_table_url_from_dimension(dimension, tablebuilder2=False):
     topic_page = subtopic_page.parent
     return url_for(
         "cms.create_table" if tablebuilder2 else "cms.create_table_original",
-        topic=topic_page.uri,
-        subtopic=subtopic_page.uri,
-        measure=measure_page.guid,
+        topic_uri=topic_page.uri,
+        subtopic_uri=subtopic_page.uri,
+        measure_uri=measure_page.guid,
         version=dimension.page_version,
-        dimension=dimension.guid,
+        dimension_guid=dimension.guid,
         _external=True,
     )
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -217,9 +217,7 @@ class CmsIndexPage(BasePage):
 
 class TopicPage(BasePage):
     def __init__(self, driver, live_server, page):
-        super().__init__(
-            driver=driver, base_url="http://localhost:%s/%s" % (live_server.port, page.guid.replace("topic_", ""))
-        )
+        super().__init__(driver=driver, base_url="http://localhost:%s/%s" % (live_server.port, page.uri))
 
     def get(self):
         url = self.base_url
@@ -284,7 +282,7 @@ class SubtopicPage(BasePage):
     def __init__(self, driver, live_server, topic_page, subtopic_page):
         super().__init__(
             driver=driver,
-            base_url="http://localhost:%s/cms/%s/%s" % (live_server.port, topic_page.guid, subtopic_page.guid),
+            base_url="http://localhost:%s/cms/%s/%s" % (live_server.port, topic_page.uri, subtopic_page.uri),
         )
 
     def get(self):
@@ -316,7 +314,7 @@ class MeasureCreatePage(BasePage):
     def __init__(self, driver, live_server, topic, subtopic):
         super().__init__(
             driver=driver,
-            base_url="http://localhost:%s/cms/%s/%s/measure/new" % (live_server.port, topic.guid, subtopic.guid),
+            base_url="http://localhost:%s/cms/%s/%s/measure/new" % (live_server.port, topic.uri, subtopic.uri),
         )
 
     def get(self):
@@ -334,11 +332,11 @@ class MeasureCreatePage(BasePage):
 
 
 class MeasureVersionsPage(BasePage):
-    def __init__(self, driver, live_server, topic_page, subtopic_page, measure_page_guid):
+    def __init__(self, driver, live_server, topic_page, subtopic_page, measure_page_uri):
         super().__init__(
             driver=driver,
             base_url="http://localhost:%s/cms/%s/%s/%s/versions"
-            % (live_server.port, topic_page.guid, subtopic_page.guid, measure_page_guid),
+            % (live_server.port, topic_page.uri, subtopic_page.uri, measure_page_uri),
         )
 
     def get(self):
@@ -910,6 +908,7 @@ class RandomMeasure:
     def __init__(self):
         factory = Faker()
         self.guid = "%s_%s" % (factory.word(), factory.random_int(1, 1000))
+        self.uri = self.guid.replace("_", "-")
         self.title = " ".join(factory.words(4))
         self.measure_summary = factory.text()
         self.summary = factory.text()
@@ -941,6 +940,7 @@ class RandomDimension:
     def __init__(self):
         factory = Faker()
         self.guid = "%s_%s" % (factory.word(), factory.random_int(1, 1000))
+        self.uri = self.guid.replace("_", "-")
         self.title = " ".join(factory.words(4))
         self.measure = "%s_%s" % (factory.word(), factory.random_int(1, 1000))
         self.time_period = " ".join(factory.words(4))
@@ -956,6 +956,7 @@ class MinimalRandomMeasure:
     def __init__(self):
         factory = Faker()
         self.guid = "%s_%s" % (factory.word(), factory.random_int(1, 1000))
+        self.uri = self.guid.replace("_", "-")
         self.version = "1.0"
         self.publication_date = factory.date("%d%m%Y")
         self.published = False

--- a/tests/functional/test_cms_delete_v1_measure.py
+++ b/tests/functional/test_cms_delete_v1_measure.py
@@ -9,7 +9,6 @@ from tests.functional.pages import (
     CmsIndexPage,
     TopicPage,
     SubtopicPage,
-    MeasureVersionsPage,
     MeasureEditPage,
     MeasureCreatePage,
     RandomMeasure,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -220,9 +220,9 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client, mock_dept_use
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -232,9 +232,9 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client, mock_dept_use
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -260,9 +260,9 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client, mock_dept_use
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -272,9 +272,9 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client, mock_dept_use
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -296,9 +296,9 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -323,9 +323,9 @@ def test_admin_user_can_remove_share_of_page_with_dept_user(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -272,9 +272,9 @@ def test_admin_user_can_share_page_with_dept_user(test_app_client, mock_dept_use
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -30,7 +30,7 @@ def test_create_measure_page(
     form = MeasurePageForm(**stub_measure_data)
 
     resp = test_app_client.post(
-        url_for("cms.create_measure_page", topic=stub_topic_page.guid, subtopic=stub_subtopic_page.guid),
+        url_for("cms.create_measure_page", topic=stub_topic_page.uri, subtopic=stub_subtopic_page.uri),
         data=form.data,
         follow_redirects=True,
     )
@@ -50,9 +50,9 @@ def test_can_not_reject_page_if_not_under_review(
     response = test_app_client.get(
         url_for(
             "cms.reject_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
             follow_redirects=True,
         )
@@ -73,9 +73,9 @@ def test_can_reject_page_under_review(
     test_app_client.get(
         url_for(
             "cms.reject_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
             follow_redirects=True,
         )
@@ -109,9 +109,9 @@ def test_admin_user_can_publish_page_in_dept_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -153,9 +153,9 @@ def test_admin_user_can_not_publish_page_not_in_department_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -175,9 +175,9 @@ def test_admin_user_can_not_publish_page_not_in_department_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -206,9 +206,9 @@ def test_non_admin_user_can_not_publish_page_in_dept_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -244,9 +244,9 @@ def test_admin_user_can_unpublish_page(
     response = test_app_client.get(
         url_for(
             "cms.unpublish_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -284,9 +284,9 @@ def test_non_admin_user_can_not_unpublish_page(
     response = test_app_client.get(
         url_for(
             "cms.unpublish_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -315,9 +315,9 @@ def test_admin_user_can_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -333,9 +333,9 @@ def test_admin_user_can_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -359,9 +359,9 @@ def test_internal_user_can_not_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -377,9 +377,9 @@ def test_internal_user_can_not_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -511,9 +511,9 @@ def test_view_edit_measure_page(test_app_client, mock_rdu_user, stub_topic_page,
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -652,9 +652,9 @@ def test_dept_user_should_not_be_able_to_delete_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -664,9 +664,9 @@ def test_dept_user_should_not_be_able_to_delete_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.delete_upload",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
             upload=upload.guid,
         )
@@ -691,9 +691,9 @@ def test_dept_user_should_not_be_able_to_edit_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -703,9 +703,9 @@ def test_dept_user_should_not_be_able_to_edit_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_upload",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
             upload=upload.guid,
         )
@@ -726,9 +726,9 @@ def test_dept_user_should_not_be_able_to_delete_dimension_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_page_with_dimension.parent.parent.guid,
-            subtopic=stub_page_with_dimension.parent.guid,
-            measure=stub_page_with_dimension.guid,
+            topic=stub_page_with_dimension.parent.parent.uri,
+            subtopic=stub_page_with_dimension.parent.uri,
+            measure=stub_page_with_dimension.uri,
             version=stub_page_with_dimension.version,
         )
     )
@@ -738,9 +738,9 @@ def test_dept_user_should_not_be_able_to_delete_dimension_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.delete_dimension",
-            topic=stub_page_with_dimension.parent.parent.guid,
-            subtopic=stub_page_with_dimension.parent.guid,
-            measure=stub_page_with_dimension.guid,
+            topic=stub_page_with_dimension.parent.parent.uri,
+            subtopic=stub_page_with_dimension.parent.uri,
+            measure=stub_page_with_dimension.uri,
             version=stub_page_with_dimension.version,
             dimension=stub_page_with_dimension.dimensions[0].guid,
         )
@@ -762,9 +762,9 @@ def test_dept_user_should_be_able_to_edit_shared_page(db_session, test_app_clien
     resp = test_app_client.post(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         data=data,
@@ -791,9 +791,9 @@ def test_dept_user_should_be_able_to_send_shared_page_to_review(
     resp = test_app_client.get(
         url_for(
             "cms.send_to_review",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -819,9 +819,9 @@ def test_dept_cannot_publish_a_shared_page(db_session, test_app_client, stub_mea
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -834,9 +834,9 @@ def test_dept_cannot_publish_a_shared_page(db_session, test_app_client, stub_mea
     resp = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_measure_page.parent.parent.guid,
-            subtopic=stub_measure_page.parent.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_measure_page.parent.parent.uri,
+            subtopic=stub_measure_page.parent.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -865,9 +865,9 @@ def test_only_allowed_users_can_see_copy_measure_button_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -886,9 +886,9 @@ def test_copy_measure_page(test_app_client, mock_dev_user, stub_topic_page, stub
     resp = test_app_client.post(
         url_for(
             "cms.copy_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -30,7 +30,7 @@ def test_create_measure_page(
     form = MeasurePageForm(**stub_measure_data)
 
     resp = test_app_client.post(
-        url_for("cms.create_measure_page", topic=stub_topic_page.uri, subtopic=stub_subtopic_page.uri),
+        url_for("cms.create_measure_page", topic_uri=stub_topic_page.uri, subtopic_uri=stub_subtopic_page.uri),
         data=form.data,
         follow_redirects=True,
     )
@@ -50,9 +50,9 @@ def test_can_not_reject_page_if_not_under_review(
     response = test_app_client.get(
         url_for(
             "cms.reject_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
             follow_redirects=True,
         )
@@ -73,9 +73,9 @@ def test_can_reject_page_under_review(
     test_app_client.get(
         url_for(
             "cms.reject_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
             follow_redirects=True,
         )
@@ -109,9 +109,9 @@ def test_admin_user_can_publish_page_in_dept_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -153,9 +153,9 @@ def test_admin_user_can_not_publish_page_not_in_department_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -175,9 +175,9 @@ def test_admin_user_can_not_publish_page_not_in_department_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -206,9 +206,9 @@ def test_non_admin_user_can_not_publish_page_in_dept_review(
     response = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -244,9 +244,9 @@ def test_admin_user_can_unpublish_page(
     response = test_app_client.get(
         url_for(
             "cms.unpublish_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -284,9 +284,9 @@ def test_non_admin_user_can_not_unpublish_page(
     response = test_app_client.get(
         url_for(
             "cms.unpublish_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -315,9 +315,9 @@ def test_admin_user_can_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -333,9 +333,9 @@ def test_admin_user_can_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -359,9 +359,9 @@ def test_internal_user_can_not_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -377,9 +377,9 @@ def test_internal_user_can_not_see_publish_unpublish_buttons_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -511,9 +511,9 @@ def test_view_edit_measure_page(test_app_client, mock_rdu_user, stub_topic_page,
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -652,9 +652,9 @@ def test_dept_user_should_not_be_able_to_delete_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -664,9 +664,9 @@ def test_dept_user_should_not_be_able_to_delete_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.delete_upload",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
             upload=upload.guid,
         )
@@ -691,9 +691,9 @@ def test_dept_user_should_not_be_able_to_edit_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -703,9 +703,9 @@ def test_dept_user_should_not_be_able_to_edit_upload_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_upload",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
             upload=upload.guid,
         )
@@ -726,9 +726,9 @@ def test_dept_user_should_not_be_able_to_delete_dimension_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_page_with_dimension.parent.parent.uri,
-            subtopic=stub_page_with_dimension.parent.uri,
-            measure=stub_page_with_dimension.uri,
+            topic_uri=stub_page_with_dimension.parent.parent.uri,
+            subtopic_uri=stub_page_with_dimension.parent.uri,
+            measure_uri=stub_page_with_dimension.uri,
             version=stub_page_with_dimension.version,
         )
     )
@@ -738,11 +738,11 @@ def test_dept_user_should_not_be_able_to_delete_dimension_if_page_not_shared(
     resp = test_app_client.get(
         url_for(
             "cms.delete_dimension",
-            topic=stub_page_with_dimension.parent.parent.uri,
-            subtopic=stub_page_with_dimension.parent.uri,
-            measure=stub_page_with_dimension.uri,
+            topic_uri=stub_page_with_dimension.parent.parent.uri,
+            subtopic_uri=stub_page_with_dimension.parent.uri,
+            measure_uri=stub_page_with_dimension.uri,
             version=stub_page_with_dimension.version,
-            dimension=stub_page_with_dimension.dimensions[0].guid,
+            dimension_guid=stub_page_with_dimension.dimensions[0].guid,
         )
     )
 
@@ -762,9 +762,9 @@ def test_dept_user_should_be_able_to_edit_shared_page(db_session, test_app_clien
     resp = test_app_client.post(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         data=data,
@@ -791,9 +791,9 @@ def test_dept_user_should_be_able_to_send_shared_page_to_review(
     resp = test_app_client.get(
         url_for(
             "cms.send_to_review",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -819,9 +819,9 @@ def test_dept_cannot_publish_a_shared_page(db_session, test_app_client, stub_mea
     resp = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -834,9 +834,9 @@ def test_dept_cannot_publish_a_shared_page(db_session, test_app_client, stub_mea
     resp = test_app_client.get(
         url_for(
             "cms.publish",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -865,9 +865,9 @@ def test_only_allowed_users_can_see_copy_measure_button_on_edit_page(
     response = test_app_client.get(
         url_for(
             "cms.edit_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,
@@ -886,9 +886,9 @@ def test_copy_measure_page(test_app_client, mock_dev_user, stub_topic_page, stub
     resp = test_app_client.post(
         url_for(
             "cms.copy_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         ),
         follow_redirects=True,

--- a/tests/test_cms_autosave.py
+++ b/tests/test_cms_autosave.py
@@ -10,9 +10,9 @@ class TestCMSAutosave:
             session["user_id"] = mock_rdu_user.id
         url = url_for(
             "cms.edit_and_preview_measure_page",
-            topic=stub_topic_page.guid,
-            subtopic=stub_subtopic_page.guid,
-            measure=stub_measure_page.guid,
+            topic=stub_topic_page.uri,
+            subtopic=stub_subtopic_page.uri,
+            measure=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
         response = test_app_client.get(url)
@@ -21,9 +21,9 @@ class TestCMSAutosave:
     @pytest.mark.parametrize(
         "url, expected_result",
         [
-            ("/cms/topic_test/subtopic_example/test-measure-page/1.0/edit_and_preview", 200),
-            ("/cms/WRONG_topic_test/subtopic_example/test-measure-page/1.0/edit_and_preview", 404),
-            ("/cms/topic_test/WRONG_subtopic_example/test-measure-page/1.0/edit_and_preview", 404),
+            ("/cms/test/example/test-measure-page/1.0/edit_and_preview", 200),
+            ("/cms/WRONG/example/test-measure-page/1.0/edit_and_preview", 404),
+            ("/cms/test/WRONG/test-measure-page/1.0/edit_and_preview", 404),
         ],
     )
     def test_topic_and_subtopic_should_belong_to_page_or_404(

--- a/tests/test_cms_autosave.py
+++ b/tests/test_cms_autosave.py
@@ -10,9 +10,9 @@ class TestCMSAutosave:
             session["user_id"] = mock_rdu_user.id
         url = url_for(
             "cms.edit_and_preview_measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
         response = test_app_client.get(url)

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -15,9 +15,9 @@ def test_create_valid_dimension(test_app_client, mock_rdu_user, stub_measure_pag
 
     url = url_for(
         "cms.create_dimension",
-        topic=stub_measure_page.parent.parent.uri,
-        subtopic=stub_measure_page.parent.uri,
-        measure=stub_measure_page.uri,
+        topic_uri=stub_measure_page.parent.parent.uri,
+        subtopic_uri=stub_measure_page.parent.uri,
+        measure_uri=stub_measure_page.uri,
         version=stub_measure_page.version,
     )
 
@@ -33,9 +33,9 @@ def test_create_dimension_without_specifying_title(test_app_client, mock_rdu_use
 
     url = url_for(
         "cms.create_dimension",
-        topic=stub_measure_page.parent.parent.uri,
-        subtopic=stub_measure_page.parent.uri,
-        measure=stub_measure_page.uri,
+        topic_uri=stub_measure_page.parent.parent.uri,
+        subtopic_uri=stub_measure_page.parent.uri,
+        measure_uri=stub_measure_page.uri,
         version=stub_measure_page.version,
     )
 
@@ -66,11 +66,11 @@ def test_update_dimension_with_valid_data(test_app_client, mock_rdu_user, stub_m
 
     url = url_for(
         "cms.edit_dimension",
-        topic=stub_measure_page.parent.parent.uri,
-        subtopic=stub_measure_page.parent.uri,
-        measure=stub_measure_page.uri,
+        topic_uri=stub_measure_page.parent.parent.uri,
+        subtopic_uri=stub_measure_page.parent.uri,
+        measure_uri=stub_measure_page.uri,
         version=stub_measure_page.version,
-        dimension=dimension.guid,
+        dimension_guid=dimension.guid,
     )
 
     resp = test_app_client.post(url, data=data, follow_redirects=False)
@@ -99,11 +99,11 @@ def test_update_dimension_with_invalid_data(test_app_client, mock_rdu_user, stub
 
     url = url_for(
         "cms.edit_dimension",
-        topic=stub_measure_page.parent.parent.uri,
-        subtopic=stub_measure_page.parent.uri,
-        measure=stub_measure_page.uri,
+        topic_uri=stub_measure_page.parent.parent.uri,
+        subtopic_uri=stub_measure_page.parent.uri,
+        measure_uri=stub_measure_page.uri,
         version=stub_measure_page.version,
-        dimension=dimension.guid,
+        dimension_guid=dimension.guid,
     )
 
     resp = test_app_client.post(url, data=data, follow_redirects=False)

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -15,9 +15,9 @@ def test_create_valid_dimension(test_app_client, mock_rdu_user, stub_measure_pag
 
     url = url_for(
         "cms.create_dimension",
-        topic=stub_measure_page.parent.parent.guid,
-        subtopic=stub_measure_page.parent.guid,
-        measure=stub_measure_page.guid,
+        topic=stub_measure_page.parent.parent.uri,
+        subtopic=stub_measure_page.parent.uri,
+        measure=stub_measure_page.uri,
         version=stub_measure_page.version,
     )
 
@@ -33,9 +33,9 @@ def test_create_dimension_without_specifying_title(test_app_client, mock_rdu_use
 
     url = url_for(
         "cms.create_dimension",
-        topic=stub_measure_page.parent.parent.guid,
-        subtopic=stub_measure_page.parent.guid,
-        measure=stub_measure_page.guid,
+        topic=stub_measure_page.parent.parent.uri,
+        subtopic=stub_measure_page.parent.uri,
+        measure=stub_measure_page.uri,
         version=stub_measure_page.version,
     )
 
@@ -66,9 +66,9 @@ def test_update_dimension_with_valid_data(test_app_client, mock_rdu_user, stub_m
 
     url = url_for(
         "cms.edit_dimension",
-        topic=stub_measure_page.parent.parent.guid,
-        subtopic=stub_measure_page.parent.guid,
-        measure=stub_measure_page.guid,
+        topic=stub_measure_page.parent.parent.uri,
+        subtopic=stub_measure_page.parent.uri,
+        measure=stub_measure_page.uri,
         version=stub_measure_page.version,
         dimension=dimension.guid,
     )
@@ -99,9 +99,9 @@ def test_update_dimension_with_invalid_data(test_app_client, mock_rdu_user, stub
 
     url = url_for(
         "cms.edit_dimension",
-        topic=stub_measure_page.parent.parent.guid,
-        subtopic=stub_measure_page.parent.guid,
-        measure=stub_measure_page.guid,
+        topic=stub_measure_page.parent.parent.uri,
+        subtopic=stub_measure_page.parent.uri,
+        measure=stub_measure_page.uri,
         version=stub_measure_page.version,
         dimension=dimension.guid,
     )

--- a/tests/test_dimension_csv_download.py
+++ b/tests/test_dimension_csv_download.py
@@ -25,11 +25,11 @@ def test_if_dimension_has_chart_download_chart_source_data(
         resp = test_app_client.get(
             url_for(
                 "static_site.dimension_file_download",
-                topic=stub_topic_page.uri,
-                subtopic=stub_subtopic_page.uri,
-                measure=stub_page_with_dimension_and_chart.uri,
+                topic_uri=stub_topic_page.uri,
+                subtopic_uri=stub_subtopic_page.uri,
+                measure_uri=stub_page_with_dimension_and_chart.uri,
                 version=stub_page_with_dimension_and_chart.version,
-                dimension=dimension.guid,
+                dimension_guid=dimension.guid,
             )
         )
         d = DimensionObjectBuilder.build(dimension)
@@ -68,11 +68,11 @@ def test_if_dimension_has_chart_and_table_download_table_source_data(
         resp = test_app_client.get(
             url_for(
                 "static_site.dimension_file_download",
-                topic=stub_topic_page.uri,
-                subtopic=stub_subtopic_page.uri,
-                measure=stub_page_with_dimension_and_chart_and_table.uri,
+                topic_uri=stub_topic_page.uri,
+                subtopic_uri=stub_subtopic_page.uri,
+                measure_uri=stub_page_with_dimension_and_chart_and_table.uri,
                 version=stub_page_with_dimension_and_chart_and_table.version,
-                dimension=dimension.guid,
+                dimension_guid=dimension.guid,
             )
         )
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -238,9 +238,9 @@ def test_latest_version_does_not_add_noindex_for_robots(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=latest_version_of_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=latest_version_of_page.uri,
             version=latest_version_of_page.version,
         )
     )
@@ -274,9 +274,9 @@ def test_latest_version_does_not_add_noindex_for_robots_when_newer_draft_exists(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=latest_published_version_of_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=latest_published_version_of_page.uri,
             version=latest_published_version_of_page.version,
         )
     )
@@ -308,9 +308,9 @@ def test_previous_version_adds_noindex_for_robots(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=outdated_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=outdated_page.uri,
             version=outdated_page.version,
         )
     )

--- a/tests/test_page_service.py
+++ b/tests/test_page_service.py
@@ -57,18 +57,6 @@ def test_get_page_by_guid(stub_measure_page):
     assert page_from_db == stub_measure_page
 
 
-def test_get_page_by_uri(stub_subtopic_page, stub_measure_page):
-    page_from_db = page_service.get_page_by_uri_and_version(
-        stub_subtopic_page.guid, stub_measure_page.uri, stub_measure_page.version
-    )
-    assert page_from_db == stub_measure_page
-
-
-def test_get_page_by_uri_raises_exception_if_page_does_not_exist():
-    with pytest.raises(PageNotFoundException):
-        page_service.get_page_by_uri_and_version("not", "known", "at all")
-
-
 def test_get_page_by_guid_raises_exception_if_page_does_not_exist():
     with pytest.raises(PageNotFoundException):
         page_service.get_page("notthere")

--- a/tests/test_review_link.py
+++ b/tests/test_review_link.py
@@ -119,9 +119,9 @@ def test_page_main_download_available_without_login(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page_file_download",
-            topic=stub_measure_page.parent.parent.uri,
-            subtopic=stub_measure_page.parent.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
             filename=stub_measure_page.uploads[0].file_name,
         )
@@ -140,11 +140,11 @@ def test_page_dimension_download_available_without_login(test_app_client, mock_r
     resp = test_app_client.get(
         url_for(
             "static_site.dimension_file_download",
-            topic=stub_page_with_dimension.parent.parent.uri,
-            subtopic=stub_page_with_dimension.parent.uri,
-            measure=stub_page_with_dimension.uri,
+            topic_uri=stub_page_with_dimension.parent.parent.uri,
+            subtopic_uri=stub_page_with_dimension.parent.uri,
+            measure_uri=stub_page_with_dimension.uri,
             version=stub_page_with_dimension.version,
-            dimension=stub_page_with_dimension.dimensions[0].guid,
+            dimension_guid=stub_page_with_dimension.dimensions[0].guid,
         )
     )
 

--- a/tests/test_static_views.py
+++ b/tests/test_static_views.py
@@ -23,9 +23,9 @@ def test_rdu_user_can_see_page_if_not_shared(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -47,9 +47,9 @@ def test_departmental_user_cannot_see_page_unless_shared(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -63,9 +63,9 @@ def test_departmental_user_cannot_see_page_unless_shared(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -90,9 +90,9 @@ def test_get_file_download_returns_404(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page_file_download",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
             filename="nofile.csv",
         )
@@ -112,9 +112,9 @@ def test_view_export_page(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page_markdown",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -215,7 +215,7 @@ def test_view_topic_page(test_app_client, mock_rdu_user, stub_topic_page):
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_rdu_user.id
 
-    resp = test_app_client.get(url_for("static_site.topic", uri=stub_topic_page.uri))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri=stub_topic_page.uri))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -230,7 +230,7 @@ def test_view_topic_page_contains_reordering_javascript_for_admin_user_only(
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_admin_user.id
 
-    resp = test_app_client.get(url_for("static_site.topic", uri=stub_topic_page.uri))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri=stub_topic_page.uri))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -240,7 +240,7 @@ def test_view_topic_page_contains_reordering_javascript_for_admin_user_only(
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_rdu_user.id
 
-    resp = test_app_client.get(url_for("static_site.topic", uri=stub_topic_page.uri))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri=stub_topic_page.uri))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -256,14 +256,14 @@ def test_view_topic_page_in_static_mode_does_not_contain_reordering_javascript(
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_admin_user.id
 
-    resp = test_app_client.get(url_for("static_site.topic", uri=stub_topic_page.uri))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri=stub_topic_page.uri))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
     assert page.h1.text.strip() == "Test topic page"
     assert len(page.find_all("script", text=re.compile("setupReorderableTables"))) == 1
 
-    resp = test_app_client.get(url_for("static_site.topic", uri=stub_topic_page.uri, static_mode=True))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri=stub_topic_page.uri, static_mode=True))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -291,7 +291,7 @@ def test_view_sandbox_topic(test_app_client, mock_rdu_user, stub_sandbox_topic_p
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_rdu_user.id
 
-    resp = test_app_client.get(url_for("static_site.topic", uri=stub_sandbox_topic_page.uri))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri=stub_sandbox_topic_page.uri))
 
     assert resp.status_code == 200
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -307,9 +307,9 @@ def test_measure_page_social_sharing(
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -342,9 +342,9 @@ def test_view_measure_page(test_app_client, mock_rdu_user, stub_topic_page, stub
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )
@@ -518,7 +518,7 @@ def test_topic_page_only_shows_subtopics_with_published_measures_for_static_site
     db_session.session.add(stub_measure_page)
     db_session.session.commit()
 
-    resp = test_app_client.get(url_for("static_site.topic", uri="test", static_mode=static_mode))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri="test", static_mode=static_mode))
     assert resp.status_code == 200
 
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -550,7 +550,7 @@ def test_topic_page_only_shows_subtopics_with_shared_or_published_measures_for_d
     db_session.session.add(stub_measure_page)
     db_session.session.commit()
 
-    resp = test_app_client.get(url_for("static_site.topic", uri="test"))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri="test"))
     assert resp.status_code == 200
 
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
@@ -565,7 +565,7 @@ def test_topic_page_only_shows_empty_subtopics_if_user_can_create_a_measure(
     with test_app_client.session_transaction() as session:
         session["user_id"] = mock_dept_user.id if user_type == "DEPT" else mock_rdu_user.id
 
-    resp = test_app_client.get(url_for("static_site.topic", uri="test"))
+    resp = test_app_client.get(url_for("static_site.topic", topic_uri="test"))
     page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
     assert resp.status_code == 200
@@ -584,9 +584,9 @@ def test_measure_page_share_links_do_not_contain_double_slashes_between_domain_a
     resp = test_app_client.get(
         url_for(
             "static_site.measure_page",
-            topic=stub_topic_page.uri,
-            subtopic=stub_subtopic_page.uri,
-            measure=stub_measure_page.uri,
+            topic_uri=stub_topic_page.uri,
+            subtopic_uri=stub_subtopic_page.uri,
+            measure_uri=stub_measure_page.uri,
             version=stub_measure_page.version,
         )
     )


### PR DESCRIPTION
Once again this PR is split into a few separate commits, mostly (hopefully) logical and separate enough to help get reviewed.

 ## Commit 1 - new index on Page table for page type+uri
This index will allow us to quickly look up pages by their URI, as well
as (filter down measures by type and uri). This will help keep lookups
performant as we move from the combination of guid+version for CMS route
resolution to page type + uri.

 ## Commit 2 - Use URIs instead of GUIDs
For the CMS routes, we currently use topic and subtopic GUIDs in the
URLs instead of their respective URIs/slugs. This leads to a weird
experience as a CMS user (with strange-looking URLs), as well as a more
confusing experience as a developer, having to remember whether you have
a GUID or a URI in a given variable called 'topic' or 'subtopic'.

This patch moves to consistently use the `uri` of a page in the URL,
which should make life a little nicer for both users and developers.

 ## Commit 3 - Rename URI route variables - optional?
Rename variables that handle topic, subtopic and measure URIs to be more
explicit about the fact they're holding a URI string (as opposed to,
say, a GUID).

 ## Ticket
https://trello.com/c/Epn14w5O/910