### PR TITLE
Remove extraneous request context

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,13 +24,6 @@ from tests.utils import UnmockedRequestException
 def app(request):
     _app = create_app(TestConfig)
 
-    ctx = _app.test_request_context()
-    ctx.push()
-
-    def teardown():
-        ctx.pop()
-
-    request.addfinalizer(teardown)
     return _app
 
 


### PR DESCRIPTION
 ## Summary
Sometimes our tests fail (for example because of undefined variables in
Jinja templates) with really unhelpful error messages like "popped wrong
request context". When this happens it obscures the real error and makes
it more difficult to understand what's gone wrong. This appears to be
due to how we currently handle request contexts during tests.

At the moment, the main `app` fixture pushes a custom request context
onto the stack at the start of the session and pops that context off at
the end of the session through a request finalizer. Then, within
specific tests that need to GET/POST/etc to pages, they use a test
client based off the `app` fixture to request those resources. As part
of this, they pop another request context onto the stack.

By default, when Flask is in DEBUG mode (which, when under test in our
codebase, it is), it doesn't pop request contexts off the stack when an
exception is raised. This is so that the developer can, in theory, look
into the request context for clues about what happened. However, in our
case, this means that when the test's teardown is called, we try to pop
the original `app`'s request context off the stack - but the test
client's request context is still there. This causes the `popped wrong
request context` error during teardown, which suppresses/obscures the
original error.

There are a few ways to remediate this:
1) Turn DEBUG to False when under test.
2) Turn PRESERVE_CONTEXT_ON_EXCEPTION to False when under test.
3) Don't push a custom `app` context onto the stack.

When under test, it feels sensible to have DEBUG turned on, as it
affects more than just the request context behaviour.
PRESERVE_CONTEXT_ON_EXCEPTION is a specific config option for the
behaviour that gives us a problem - but given that it is there to help
developers debug issues with contexts when errors arise, it feels
potentially awkward to turn off, as it may make difficult/complex issues
harder to debug if they do come up.

Therefore I've opted to remove the custom `app` context, which in our
case seems to do nothing for us. We actually already have an implicit
app context managed for us by the `pytest-flask` extension
(https://pytest-flask.readthedocs.io/en/latest/features.html#request-ctx-request-context),
which pushes and maintains a request context whenever we use the `app`
fixture.

 ## Ticket
https://trello.com/c/n09eYiz9/914