### PR TITLE
Fix static site links with trailing slashes

### DIFF
--- a/application/admin/views.py
+++ b/application/admin/views.py
@@ -11,7 +11,7 @@ from application.cms.models import Page, user_page
 from application.utils import create_and_send_activation_email, user_can
 
 
-@admin_blueprint.route("/")
+@admin_blueprint.route("")
 @login_required
 @user_can(MANAGE_USERS)
 def index():

--- a/application/cms/views.py
+++ b/application/cms/views.py
@@ -58,7 +58,7 @@ from application.sitebuilder.build_service import request_build
 from application.utils import get_bool, user_can, user_has_access
 
 
-@cms_blueprint.route("/")
+@cms_blueprint.route("")
 @login_required
 def index():
     return redirect(url_for("static_site.index"))

--- a/application/dashboard/views.py
+++ b/application/dashboard/views.py
@@ -20,7 +20,7 @@ from application.factory import page_service
 from application.utils import user_can
 
 
-@dashboard_blueprint.route("/")
+@dashboard_blueprint.route("")
 @login_required
 @user_can(VIEW_DASHBOARDS)
 def index():

--- a/application/factory.py
+++ b/application/factory.py
@@ -74,6 +74,8 @@ def create_app(config_object):
 
     db.init_app(app)
 
+    app.url_map.strict_slashes = False
+
     app.dictionary_lookup = EthnicityDictionaryLookup(
         lookup_file=config_object.DICTIONARY_LOOKUP_FILE, default_values=config_object.DICTIONARY_LOOKUP_DEFAULTS
     )

--- a/application/redirects/views.py
+++ b/application/redirects/views.py
@@ -48,7 +48,7 @@ def _build_routing_rules_xml(redirects):
     return tostring(root)
 
 
-@redirects_blueprint.route("/")
+@redirects_blueprint.route("")
 @login_required
 def index():
     return Response(_build_routing_rules_xml(Redirect.query.all()), mimetype="text/xml")

--- a/application/static_site/__init__.py
+++ b/application/static_site/__init__.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
 
-static_site_blueprint = Blueprint("static_site", __name__)
+static_site_blueprint = Blueprint("static_site", __name__, url_prefix="/")
 
 from application.static_site.views import index  # noqa

--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -25,7 +25,7 @@ from application.utils import (
 from application.cms.api_builder import build_index_json, build_measure_json
 
 
-@static_site_blueprint.route("/")
+@static_site_blueprint.route("")
 @login_required
 def index():
     topics = (


### PR DESCRIPTION
 ## Summary
Some of our routes have trailing slashes and others don't (for example,
`/users/` vs `/admin`. This gives us inconsistent URLs and makes it
harder to predict what structure we need when we export the site to
static files and upload it to S3. This PR moves us to having **no
trailing slashes** by default - though also disables Flask's strict
handling of slashes - so if a trailing slash is provided, it will
redirect to the non-trailing version with a 302. The trailing slash
historically implied a directory-like structure, which isn't really what
we have. We have a set of browsable pages, so sans-slash feels fine.

Given that we now also serve our static files from an S3 bucket which is
enabled for web hosting, it will automatically resolve something like
`/users` down to `/users/index.html`, which lets us remove the extra
step in the s3_deployer that moves index files up a directory level and
flattens them out into just `/users`. This simplifies our build process
and gives us a slightly more standard file layout.

 ## Research
https://webmasters.googleblog.com/2010/04/to-slash-or-not-to-slash.html
https://www.seoblog.com/2018/05/remove-trailing-slash-urls/
https://stackoverflow.com/questions/33241050/trailing-slash-triggers-404-in-flask-path-rule

 ## Deployment process
When this goes out, some objects in the S3 bucket will no longer get
updated, but could potentially get served if the correct URL is hit. We
will need to manually remove these keys so that S3/CloudFront can start
serving the new ones and redirecting as appropriate. These keys will
mainly be at the top level(s) of the bucket, where keys have been
translated from a/b/c/index.html to a/b/c (or whatever).

 ## Ticket
https://trello.com/c/0J4BvUYA/1108