### PR TITLE
Since Flask 1.x developers need to set FLASK_ENV=development

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ root of the project containing the values below. This file should not be committ
 and therefore any variables needed for the application need to be set manually on Heroku.
 ```
 ACCOUNT_WHITELIST="['your email address if it is not a gov.uk one']"
+FLASK_ENV=development
 ENVIRONMENT=DEVELOPMENT
 DATABASE_URL=postgresql://postgres@localhost:5432/rdcms
 TEST_DATABASE_URL=postgresql://postgres@localhost:5432/rdcms_test


### PR DESCRIPTION
To avoid the warning
```
WARNING: Do not use the development server in a production environment.

```
when running Flask locally devs now need to specify FLASK_ENV, which defaults to "production" if no value is specified.

See http://flask.pocoo.org/docs/1.0/config/