### PR TITLE
Sort topics in Python not Postgres

### DIFF
--- a/application/static_site/views.py
+++ b/application/static_site/views.py
@@ -28,8 +28,9 @@ from application.cms.api_builder import build_index_json, build_measure_json
 @static_site_blueprint.route("/")
 @login_required
 def index():
-    topics = (
-        Page.query.filter(Page.page_type == "topic", Page.parent_guid == "homepage").order_by(Page.title.asc()).all()
+    topics = sorted(
+        Page.query.filter(Page.page_type == "topic", Page.parent_guid == "homepage").all(),
+        key=lambda topic: topic.title,
     )
 
     return render_template(


### PR DESCRIPTION
Postgres 9.6 seems to sort "Workforce and business" ahead of "Work, pay and benefits", which seems... wrong.

So sorting in Python for now. This seems to be "fixed" in Postgres 10+

Fixes https://trello.com/c/C1tgJoNM/1111-w-topics-transposed-in-publisher-and-live-site