### PR TITLE
Remove manual scrolling

### DIFF
--- a/application/src/js/cms/_govuk_government_organisations_autocomplete.js
+++ b/application/src/js/cms/_govuk_government_organisations_autocomplete.js
@@ -80,6 +80,12 @@ var govukGovernmentOrganisationsAutocomplete = function(options) {
 
     var results = sortedFilteredMatches.map(function(organisation) { return organisation['current_name'] })
 
+    console.log('results:')
+
+    for (var i = 0; i < results.length; i++) {
+      console.log(results[i])
+    }
+
     return callback(results)
   }
 
@@ -88,4 +94,5 @@ var govukGovernmentOrganisationsAutocomplete = function(options) {
 
   accessibleAutocomplete.enhanceSelectElement(options)
 
+  console.log('autocomplete initialised')
 }

--- a/application/src/js/cms/_govuk_government_organisations_autocomplete.js
+++ b/application/src/js/cms/_govuk_government_organisations_autocomplete.js
@@ -80,6 +80,8 @@ var govukGovernmentOrganisationsAutocomplete = function(options) {
 
     var results = sortedFilteredMatches.map(function(organisation) { return organisation['current_name'] })
 
+    console.log('query: ' + query)
+
     console.log('results:')
 
     for (var i = 0; i < results.length; i++) {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,5 @@ display_result $? 1 "Code style check"
 npx gulp
 display_result $? 2 "Frontend asset build check"
 
-py.test
+py.test -s
 display_result $? 3 "Python tests"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,5 @@ display_result $? 1 "Code style check"
 npx gulp
 display_result $? 2 "Frontend asset build check"
 
-py.test -s
+py.test -sktest_can_reject_a_measure_in_review_as_editor
 display_result $? 3 "Python tests"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,5 @@ display_result $? 1 "Code style check"
 npx gulp
 display_result $? 2 "Frontend asset build check"
 
-py.test -sktest_can_reject_a_measure_in_review_as_editor
+py.test -s
 display_result $? 3 "Python tests"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,8 +92,6 @@ def db(app):
 
 @pytest.fixture(scope="function")
 def db_session(db):
-    yield db
-
     db.session.remove()
 
     # this deletes any data in tables, but if you want to start from scratch (i.e. migrations etc, drop everything)
@@ -121,6 +119,8 @@ def db_session(db):
             db.engine.execute(tbl.delete())
 
     db.session.commit()
+
+    yield db
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -750,3 +750,7 @@ def pytest_sessionfinish(session, exitstatus):
         print("Extracting selenium screenshots")
     else:
         print("Not running on CI server; leaving files in place.")
+
+    import subprocess
+
+    print(subprocess.check_output(["chromedriver", "-v"]))

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -31,12 +31,15 @@ def _driver():
         # This is for CI, heroku chrome buildpack sets GOOGLE_CHROME_BIN itself
         # but we need to set CHROMEDRIVER_PATH ourselves so make sure env variable
         # for that is set correctly
+        d = DesiredCapabilities.CHROME
+        d["loggingPrefs"] = {"browser": "ALL"}
+
         GOOGLE_CHROME_SHIM = os.environ["GOOGLE_CHROME_SHIM"]
         CHROMEDRIVER_PATH = os.environ["CHROMEDRIVER_PATH"]
         options = webdriver.ChromeOptions()
         options.add_argument("--headless")
         options.binary_location = GOOGLE_CHROME_SHIM
-        driver = webdriver.Chrome(chrome_options=options, executable_path=CHROMEDRIVER_PATH)
+        driver = webdriver.Chrome(chrome_options=options, desired_capabilities=d, executable_path=CHROMEDRIVER_PATH)
 
     elif driver_name == "phantomjs":
         driver = webdriver.PhantomJS()

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -441,10 +441,10 @@ class MeasureEditPage(BasePage):
 
         print("Browser logs:")
 
-        logs = self.driver.get_log('browser')
+        logs = self.driver.get_log("browser")
 
         for log in logs:
-            print(log['message'])
+            print(log["message"])
 
         element = self.wait_for_element((By.ID, "department-source__option--0"))
         element.click()

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -436,7 +436,7 @@ class MeasureEditPage(BasePage):
         element.clear()
         element.send_keys(value)
 
-        hidden_field = self.driver.find_element_by_id('department-source-select')
+        hidden_field = self.driver.find_element_by_id("department-source-select")
 
         print("Browser logs:")
 
@@ -447,12 +447,10 @@ class MeasureEditPage(BasePage):
 
         print("Selected: " + Select(hidden_field).first_selected_option.get_attribute("value"))
 
-
         element = self.driver.find_element_by_id("department-source__option--0")
         element.click()
 
         print("Selected: " + Select(hidden_field).first_selected_option.get_attribute("value"))
-
 
         # time.sleep(5)
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -447,6 +447,8 @@ class MeasureEditPage(BasePage):
 
         print("Selected: " + Select(hidden_field).first_selected_option.get_attribute("value"))
 
+        print(self.driver.page_source)
+
         element = self.driver.find_element_by_id("department-source__option--0")
         element.click()
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -443,8 +443,8 @@ class MeasureEditPage(BasePage):
         for log in logs:
             print(log["message"])
 
-        wait = WebDriverWait(self.driver, 10)
-        wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
+        # wait = WebDriverWait(self.driver, 10)
+        # wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
 
         element = self.wait_for_element((By.ID, "department-source__option--0"))
         element.click()

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -446,7 +446,7 @@ class MeasureEditPage(BasePage):
         # wait = WebDriverWait(self.driver, 10)
         # wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
 
-        element = self.wait_for_element((By.ID, "department-source__option--0"))
+        element = self.driver.find_element_by_id("department-source__option--0")
         element.click()
 
         # time.sleep(5)

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -439,8 +439,17 @@ class MeasureEditPage(BasePage):
         wait = WebDriverWait(self.driver, 10)
         wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
 
+        print("Browser logs:")
+
+        logs = self.driver.get_log('browser')
+
+        for log in logs:
+            print(log['message'])
+
         element = self.wait_for_element((By.ID, "department-source__option--0"))
         element.click()
+
+        # time.sleep(5)
 
         # element.send_keys(Keys.ENTER)
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -436,15 +436,15 @@ class MeasureEditPage(BasePage):
         element.clear()
         element.send_keys(value)
 
-        wait = WebDriverWait(self.driver, 10)
-        wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
-
         print("Browser logs:")
 
         logs = self.driver.get_log("browser")
 
         for log in logs:
             print(log["message"])
+
+        wait = WebDriverWait(self.driver, 10)
+        wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
 
         element = self.wait_for_element((By.ID, "department-source__option--0"))
         element.click()

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -423,18 +423,23 @@ class MeasureEditPage(BasePage):
         element.send_keys(value)
 
     def set_auto_complete_field(self, locator, value):
+        from selenium.webdriver.support.ui import WebDriverWait
+        from selenium.webdriver.support import expected_conditions as EC
+
         body = self.driver.find_element_by_tag_name("body")
         element = self.wait_for_element(locator)
 
-        body.send_keys(Keys.CONTROL + Keys.HOME)
         actions = ActionChains(self.driver)
-        actions.move_to_element(element)
-        actions.send_keys_to_element(body, 8 * Keys.ARROW_UP)
         actions.move_to_element(element)
         actions.perform()
 
         element.clear()
         element.send_keys(value)
+
+        wait = WebDriverWait(self.driver, 10)
+        wait.until(EC.visibility_of_element_located((By.ID, "department-source__listbox")))
+
+        element.send_keys(Keys.ENTER)
 
     def set_title(self, title):
         self.set_text_field(EditMeasureLocators.TITLE_INPUT, title)
@@ -509,7 +514,7 @@ class MeasureEditPage(BasePage):
         self.set_lowest_level_of_geography(lowest_level="0")
 
         self.set_primary_title(value=page.source_text)
-        self.set_primary_publisher(value="DWP\n")
+        self.set_primary_publisher(value="DWP")
         self.set_primary_url(value=page.source_url)
         self.set_primary_frequency()
         self.set_primary_type_of_statistic()

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -439,6 +439,8 @@ class MeasureEditPage(BasePage):
         wait = WebDriverWait(self.driver, 10)
         wait.until(EC.visibility_of_element_located((By.ID, "department-source__listbox")))
 
+        time.sleep(2)
+
         element.send_keys(Keys.ENTER)
 
     def set_title(self, title):

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -436,6 +436,8 @@ class MeasureEditPage(BasePage):
         element.clear()
         element.send_keys(value)
 
+        hidden_field = self.driver.find_element_by_id('department-source-select')
+
         print("Browser logs:")
 
         logs = self.driver.get_log("browser")
@@ -443,11 +445,14 @@ class MeasureEditPage(BasePage):
         for log in logs:
             print(log["message"])
 
-        # wait = WebDriverWait(self.driver, 10)
-        # wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
+        print("Selected: " + Select(hidden_field).first_selected_option.get_attribute("value"))
+
 
         element = self.driver.find_element_by_id("department-source__option--0")
         element.click()
+
+        print("Selected: " + Select(hidden_field).first_selected_option.get_attribute("value"))
+
 
         # time.sleep(5)
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -437,9 +437,9 @@ class MeasureEditPage(BasePage):
         element.send_keys(value)
 
         wait = WebDriverWait(self.driver, 10)
-        wait.until(EC.visibility_of_element_located((By.ID, "department-source__listbox")))
+        wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
 
-        time.sleep(2)
+        # time.sleep(2)
 
         element.send_keys(Keys.ENTER)
 

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -434,6 +434,7 @@ class MeasureEditPage(BasePage):
         actions.perform()
 
         element.clear()
+        element.clear()
         element.send_keys(value)
 
         hidden_field = self.driver.find_element_by_id("department-source-select")

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -433,8 +433,9 @@ class MeasureEditPage(BasePage):
         actions.move_to_element(element)
         actions.perform()
 
-        element.clear()
-        element.clear()
+        element.send_keys(Keys.CONTROL + "a")
+        element.send_keys(Keys.DELETE)
+
         element.send_keys(value)
 
         hidden_field = self.driver.find_element_by_id("department-source-select")

--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -439,9 +439,10 @@ class MeasureEditPage(BasePage):
         wait = WebDriverWait(self.driver, 10)
         wait.until(EC.visibility_of_element_located((By.ID, "department-source__option--0")))
 
-        # time.sleep(2)
+        element = self.wait_for_element((By.ID, "department-source__option--0"))
+        element.click()
 
-        element.send_keys(Keys.ENTER)
+        # element.send_keys(Keys.ENTER)
 
     def set_title(self, title):
         self.set_text_field(EditMeasureLocators.TITLE_INPUT, title)


### PR DESCRIPTION
 ## Summary
Our Heroku tests have been broken for about a week because of an
inability to get past a specific Selenium test - specifically one that
creates a new measure and then tries to set a publisher on it. Upon
sending it to review, a validation error occurred because the select
option for 'Department of Work and Pensions' had not been correctly
selected by the driver.

Removing these random 8 presses of the UP key seem to allow Heroku's
chromedriver to confirm the option selection.

This isn't a particularly _satisfying_ fix, because it's very difficult
to validate **why** this was happening, and indeed that it **has** been
definitively fixed. But it looks like it's fixed us (for now)...

 ## Ticket
https://trello.com/c/qDRWxakt/1120