### PR TITLE
Clear text input manually

### DIFF
--- a/tests/functional/pages.py
+++ b/tests/functional/pages.py
@@ -426,14 +426,9 @@ class MeasureEditPage(BasePage):
         body = self.driver.find_element_by_tag_name("body")
         element = self.wait_for_element(locator)
 
-        body.send_keys(Keys.CONTROL + Keys.HOME)
-        actions = ActionChains(self.driver)
-        actions.move_to_element(element)
-        actions.send_keys_to_element(body, 8 * Keys.ARROW_UP)
-        actions.move_to_element(element)
-        actions.perform()
+        element.send_keys(Keys.CONTROL + "a")
+        element.send_keys(Keys.DELETE)
 
-        element.clear()
         element.send_keys(value)
 
     def set_title(self, title):


### PR DESCRIPTION
 ## Summary
We think that selenium's chromedriver `element.clear()` does not work
correctly on some Heroku instances. It looks like doing a CTRL+A, DEL
within the element might clear it successfully. This might be because
the manual key-based method triggers the appropriate JS events for our
autocomplete text input, whereas `.clear()` does not.

The above doesn't really explain everything though .. like why sometimes tests _do_ pass on Heroku.

 ## Ticket
https://trello.com/c/qDRWxakt/1120


Props to @frankieroberto for discovering.