### PR TITLE
Fix static site build

### DIFF
--- a/application/sitebuilder/build.py
+++ b/application/sitebuilder/build.py
@@ -18,6 +18,7 @@ from application.cms.upload_service import upload_service
 from application.utils import get_csv_data_for_download, write_dimension_csv, write_dimension_tabular_csv
 from application.cms.api_builder import build_measure_json, build_index_json
 
+
 BUILD_TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S.%f"
 
 
@@ -175,8 +176,8 @@ def write_measure_page(page, build_dir, json_enabled=False, latest=False, local_
 
     content = render_template(
         "static_site/measure.html",
-        topic=page.parent.parent.uri,
-        subtopic=page.parent.uri,
+        topic_uri=page.parent.parent.uri,
+        subtopic_uri=page.parent.uri,
         measure_page=page,
         dimensions=dimensions,
         versions=versions,


### PR DESCRIPTION
 ## Summary
https://github.com/racedisparityaudit/rd_cms/pull/803 renamed a number
of variables used in templates, but didn't update render_template
arguments in tests, so this slipped in. I've run the static site build
locally and it now passes.

I'm going to look into how we might test the static site build process
so that these sort of bugs don't creep in, but getting this in now
should unblock the pipeline.