### PR TITLE
Rudimentary test for static site build

### DIFF
--- a/application/sitebuilder/build_service.py
+++ b/application/sitebuilder/build_service.py
@@ -31,6 +31,7 @@ def request_build():
     build.id = str(uuid.uuid4())
     db.session.add(build)
     db.session.commit()
+    return build
 
 
 def build_site(app):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,18 @@ def app(request):
     return _app
 
 
+@pytest.fixture(scope="function")
+def single_use_app():
+    """
+    A function-scoped app fixture. This should only be used for testing the static site building process, as that
+    process requires an app which has not yet handled any requests. This is the case for all management commands, which
+    are run on Heroku in unroutable, single-use instances of our app.
+    """
+    _app = create_app(TestConfig)
+
+    return _app
+
+
 # Runs database migrations once at the start of the test session - required to set up materialized views
 @pytest.fixture(autouse=True, scope="session")
 def db_migration():

--- a/tests/test_build_static_site.py
+++ b/tests/test_build_static_site.py
@@ -1,0 +1,42 @@
+import pytest
+import time
+from unittest.mock import patch, MagicMock
+
+from application.sitebuilder.build import do_it
+from application.sitebuilder.build_service import request_build
+from tests.utils import UnexpectedMockInvocationException
+
+
+def test_static_site_build(single_use_app, stub_home_page, stub_published_measure_page):
+    """
+    A basic test for the core flow of the static site builder. This patches/mocks a few of the key integrations to 
+    help prevent calling out to external services accidentally, and where possible, includes two levels of failsafes.
+    1) We change the application config to not push/deploy the site
+    2) We mock out the push_site, so that even if the config setting fails, this test will raise an error.
+    
+    Unfortunately, due to circular dependencies between build/build_service, it's not easy to mock out `deploy_site`.
+    So we mock out the S3FileSystem, which is initialized within `deloy_site`. This will throw an error if invoked.
+    
+    `create_versioned_assets` is mocked out because that function is only needed to generate css/js, which is tested
+    in a separate step outside of pytest.
+    
+    `write_html` is mocked out so that we don't need to be able to write to a filesystem.
+    
+    We should look at expanding test coverage of the static site builder eventually, but such a task should probably
+    also include refactoring the site builder to be more modular, less tightly-coupled, and more easy to test.
+    """
+    with patch.dict(single_use_app.config):
+        with patch("application.sitebuilder.build.push_site") as push_site_patch:
+            with patch("application.sitebuilder.build.pull_current_site") as pull_current_site_patch:
+                with patch("application.sitebuilder.build_service.S3FileSystem") as s3_fs_patch:
+                    with patch("application.dashboard.data_helpers.trello_service") as trello_service_patch:
+                        with patch("application.sitebuilder.build.create_versioned_assets"):
+                            with patch("application.sitebuilder.build.write_html"):
+                                single_use_app.config["PUSH_SITE"] = False
+                                single_use_app.config["DEPLOY_SITE"] = False
+                                pull_current_site_patch.side_effect = UnexpectedMockInvocationException
+                                push_site_patch.side_effect = UnexpectedMockInvocationException
+                                s3_fs_patch.side_effect = UnexpectedMockInvocationException
+                                trello_service_patch.get_measure_cards.return_value = []
+
+                                do_it(single_use_app, request_build())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,3 +4,7 @@ class GeneralTestException(Exception):
 
 class UnmockedRequestException(GeneralTestException):
     pass
+
+
+class UnexpectedMockInvocationException(GeneralTestException):
+    pass


### PR DESCRIPTION
 ## Summary
I've merged a few commits over the last months that have broken static
site builds. This is, in part, due to a lack of testing around this
process. This patch introduces a rudimentary test for the static site
build process - it will generate a set of pages (homepage, topic page,
measure page, dashboards, 'Ethnicity in the UK' static pages) and send
them to /dev/null. The main thing this tests is that the core templates
for the static site can be called correctly and return without raising
errors. This is not a thorough test for the site builder, but it should
give us _some_ level of assurance, where previously there was none
(beyond manual QA).

 ## Ticket
https://trello.com/c/7Z2PQnb1/1138