### PR TITLE
Fix planned pages dashboard

### DIFF
--- a/application/src/sass/_measure_progress_dashboard.scss
+++ b/application/src/sass/_measure_progress_dashboard.scss
@@ -1,0 +1,60 @@
+/* DASHBOARDS */
+$dashboard-background-highlight: #005EA5;
+$dashboard-background-light: #F5F5F5;
+$dashboard-background-bold: #BFC1C3;
+
+
+/* Measure progress table */
+.measure-table td, .measure-table th {
+  text-align: left;
+}
+
+.progress__title {
+  margin-bottom: 40px;
+}
+
+.progress__explanatory-text {
+  margin-bottom: 30px;
+
+  &__link {
+    &,
+    &:link,
+    &:visited {
+      color: $black;
+      text-decoration: none;
+      cursor: pointer;
+      font-weight: 700;
+    }
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.progress-card {
+  // FUNCTIONALITY
+  height: 80px;
+  background-color: $dashboard-background-light;
+  text-align: center;
+  padding: 10px;
+  margin-bottom: 20px;
+  border-radius: 3px;
+
+  &--selected {
+    color: white;
+    background-color: $dashboard-background-highlight;
+  }
+
+  &--active {
+    &:hover {
+      background-color: $dashboard-background-bold;
+      color: white;
+      cursor: pointer;
+    }
+  }
+
+  &__value {
+    font-size: 5rem;
+  }
+
+}

--- a/application/src/sass/application.scss
+++ b/application/src/sass/application.scss
@@ -28,3 +28,4 @@
 @import '_breadcrumbs';
 @import '_overrides';
 @import '_auto_resize_textarea';
+@import '_measure_progress_dashboard';

--- a/application/src/sass/cms.scss
+++ b/application/src/sass/cms.scss
@@ -719,66 +719,6 @@ fieldset.uk-countries .uk {
   margin-top: 25px;
 }
 
-/* DASHBOARDS */
-$dashboard-background-highlight: #005EA5;
-$dashboard-background-light: #F5F5F5;
-$dashboard-background-bold: #BFC1C3;
-
-
-/* Measure progress table */
-.measure-table td, .measure-table th {
-  text-align: left;
-}
-
-.progress__title {
-  margin-bottom: 40px;
-}
-
-.progress__explanatory-text {
-  margin-bottom: 30px;
-
-  &__link {
-    &,
-    &:link,
-    &:visited {
-      color: $black;
-      text-decoration: none;
-      cursor: pointer;
-      font-weight: 700;
-    }
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.progress-card {
-  // FUNCTIONALITY
-  height: 80px;
-  background-color: $dashboard-background-light;
-  text-align: center;
-  padding: 10px;
-  margin-bottom: 20px;
-  border-radius: 3px;
-
-  &--selected {
-    color: white;
-    background-color: $dashboard-background-highlight;
-  }
-
-  &--active {
-    &:hover {
-      background-color: $dashboard-background-bold;
-      color: white;
-      cursor: pointer;
-    }
-  }
-
-  &__value {
-    font-size: 5rem;
-  }
-
-}
 
 table.ethnicity-categorisations th.numeric {
   width: 100px;


### PR DESCRIPTION
The [planned pages](https://www.ethnicity-facts-figures.service.gov.uk/dashboards/measure-progress) dashboard accidentally lost its javascript in a previous refactor, as the styles were included within `cms.scss` which is no longer included on the static page.

This fixes the dashboard by moving those styles to their own file, and including them from the main application css.