### PR TITLE
Separate lines for updates and new pages on the dashboard

### DIFF
--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -40,6 +40,20 @@ def format_versions(number):
     return "%s&nbsp;versions" % number
 
 
+def index_of_last_initial_zero(list):
+    index_of_last_zero = None
+    for index, value in enumerate(list):
+        if value == 0:
+            index_of_last_zero = index
+        else:
+            break
+
+    if index_of_last_zero == None:
+        raise ValueError("List contains no 0 values")
+
+    return index_of_last_zero
+
+
 def format_status(state):
     status_names = {
         "DRAFT": "Draft",

--- a/application/cms/filters.py
+++ b/application/cms/filters.py
@@ -40,15 +40,15 @@ def format_versions(number):
     return "%s&nbsp;versions" % number
 
 
-def index_of_last_initial_zero(list):
+def index_of_last_initial_zero(list_):
     index_of_last_zero = None
-    for index, value in enumerate(list):
+    for index, value in enumerate(list_):
         if value == 0:
             index_of_last_zero = index
         else:
             break
 
-    if index_of_last_zero == None:
+    if index_of_last_zero is None:
         raise ValueError("List contains no 0 values")
 
     return index_of_last_zero

--- a/application/dashboard/data_helpers.py
+++ b/application/dashboard/data_helpers.py
@@ -60,7 +60,8 @@ def get_published_dashboard_data():
     }
 
     weeks = []
-    cumulative_total = []
+    cumulative_number_of_pages = []
+    cumulative_number_of_major_updates = []
 
     # week by week rows
     for d in _from_month_to_month(first_publication.publication_date, date.today()):
@@ -72,14 +73,22 @@ def get_published_dashboard_data():
                 updates = [updated_page for updated_page in major_updates if _page_in_week(updated_page, week)]
                 weeks.append({"week": week[0], "publications": publications, "major_updates": updates})
 
-                if not cumulative_total:
-                    cumulative_total.append(len(publications) + len(updates))
+                if not cumulative_number_of_major_updates:
+                    cumulative_number_of_major_updates.append(len(updates))
                 else:
-                    last_total = cumulative_total[-1]
-                    cumulative_total.append(last_total + len(publications) + len(updates))
+                    last_total = cumulative_number_of_major_updates[-1]
+                    cumulative_number_of_major_updates.append(last_total + len(updates))
+
+                if not cumulative_number_of_pages:
+                    cumulative_number_of_pages.append(len(publications))
+                else:
+                    last_total = cumulative_number_of_pages[-1]
+                    cumulative_number_of_pages.append(last_total + len(publications))
+
     weeks.reverse()
     data["weeks"] = weeks
-    data["graph_values"] = cumulative_total
+    data["cumulative_number_of_pages"] = cumulative_number_of_pages
+    data["cumulative_number_of_major_updates"] = cumulative_number_of_major_updates
 
     return data
 

--- a/application/dashboard/data_helpers.py
+++ b/application/dashboard/data_helpers.py
@@ -87,8 +87,8 @@ def get_published_dashboard_data():
 
     weeks.reverse()
     data["weeks"] = weeks
-    data["cumulative_number_of_pages"] = cumulative_number_of_pages
-    data["cumulative_number_of_major_updates"] = cumulative_number_of_major_updates
+    data["total_page_count_each_week"] = cumulative_number_of_pages
+    data["total_major_updates_count_each_week"] = cumulative_number_of_major_updates
 
     return data
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -27,7 +27,7 @@ from application.cms.filters import (
     format_friendly_short_date_with_year,
     format_versions,
     format_status,
-    index_of_last_initial_zero
+    index_of_last_initial_zero,
 )
 from application.cms.dimension_service import dimension_service
 from application.cms.page_service import page_service

--- a/application/factory.py
+++ b/application/factory.py
@@ -27,6 +27,7 @@ from application.cms.filters import (
     format_friendly_short_date_with_year,
     format_versions,
     format_status,
+    index_of_last_initial_zero
 )
 from application.cms.dimension_service import dimension_service
 from application.cms.page_service import page_service
@@ -133,6 +134,7 @@ def create_app(config_object):
     app.add_template_filter(join_enum_display_names)
     app.add_template_filter(slugify_value)
     app.add_template_filter(first_bullet)
+    app.add_template_filter(index_of_last_initial_zero)
 
     # There is a CSS caching problem in chrome
     app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 10

--- a/application/src/sass/_overrides.scss
+++ b/application/src/sass/_overrides.scss
@@ -13,3 +13,12 @@ Naming convention follows https://design-system.service.gov.uk/styles/spacing/
 .eff-\!-padding-bottom-40 {
   padding-bottom: 40px;
 }
+
+/* Overrides for specific colours */
+.background-light-blue {
+  background-color: $light-blue;
+}
+
+.background-turquoise {
+  background-color: $turquoise;
+}

--- a/application/templates/dashboards/graphs.html
+++ b/application/templates/dashboards/graphs.html
@@ -38,25 +38,12 @@
             <circle cx="{{ (loop.index0 * xScale) + left_margin + 0.5 }}" cy="{{ (graph_height - bottom_margin) - (value * yScale) }}" r="4" fill="#2B8CC4" />
           {% endfor %}
 
-          {# Set the last_non_zero_index variable to be the index of the
-             the last value which is a zero, so that we can use that to start the
-             graph from there, rather than showing a line along the bottom.
-           #}
-          {% set ns = namespace(last_non_zero_index = 0) %}
-          {% for value in data.cumulative_number_of_major_updates %}
 
-            {% if value == 0 %}
-              {% set ns.last_non_zero_index = loop.index0 %}
-            {% endif %}
-
-          {% endfor %}
-
-
-          {# Create the line for the cumalative number of updates, starting last zero
+          {# Create the line for the cumulative number of updates, starting last zero
              value before the line starts going up.
            #}
           <path d="
-          M{{ ((ns.last_non_zero_index + 1) * xScale) + left_margin + 0.5 }},{{ (graph_height - bottom_margin) - (0 * yScale) }}
+          M{{ ((data.cumulative_number_of_major_updates|index_of_last_initial_zero + 1) * xScale) + left_margin + 0.5 }},{{ (graph_height - bottom_margin) - (0 * yScale) }}
           {% for value in data.cumulative_number_of_major_updates %}
 
             {% if value != 0 %}

--- a/application/templates/dashboards/graphs.html
+++ b/application/templates/dashboards/graphs.html
@@ -1,72 +1,69 @@
+
+{% macro render_value_line(values, x_scale, y_scale, graph_height, colour, start_index=0) %}
+  {% set start_index_scaled = (start_index * x_scale) %}
+  <path d="
+  {% for value in values[start_index:] %}
+      {% if loop.index0 == 0 %}M{% else %}L{% endif %}
+      {{ (loop.index0 * x_scale) + start_index_scaled + 0.5 }} {{ (graph_height) - (value * y_scale) }}
+  {% endfor %}
+  " stroke-width="2" stroke="{{ colour }}" fill="none" />
+{% endmacro %}
+
+{% macro render_value_circles(values, x_scale, y_scale, graph_height, colour="#2B8CC4", start_index=0) %}
+  {% set start_index_scaled = (start_index * x_scale) %}
+  {% for value in values[start_index:] %}
+    <circle cx="{{ (loop.index0 * x_scale) + start_index_scaled + 0.5 }}" cy="{{ graph_height - (value * y_scale) }}" r="4" fill="{{ colour }}" />
+  {% endfor %}
+{% endmacro %}
+
+{% macro render_value_label(value, index, x_scale, y_scale, graph_height, text_anchor='start', vertical_offset=20, unit='') %}
+
+  <text x="{{ index * x_scale }}" y="{{ graph_height - (value * y_scale) + vertical_offset }}" text-anchor="{{ text_anchor }}" style="font-size: 16px;">{{ value }} {{ unit }}</text>
+
+{% endmacro %}
+
 {%  macro render_line_graph(data, graph_height, graph_width, left_margin, right_margin, top_margin, bottom_margin) %}
 
-        <svg viewbox="0 0 {{ graph_width }} {{ graph_height }}" style="width: 100%; margin-bottom: 10px;">
+  <svg viewbox="0 0 {{ graph_width }} {{ graph_height }}" style="width: 100%; margin-bottom: 10px;">
 
-          <rect width="{{ graph_width }}" height="{{ graph_height }}" x="0" y="0" fill="#F5F5F5" />
+    <rect width="{{ graph_width }}" height="{{ graph_height }}" x="0" y="0" fill="#F5F5F5" />
 
-          {% if data.cumulative_number_of_pages|length > 1 %}
-          {% set xScale = (graph_width - (left_margin + right_margin)) / (data.cumulative_number_of_pages|length - 1) %}
-          {% set yScale = (graph_height - (top_margin + bottom_margin)) / (data.cumulative_number_of_pages|last) %}
-
-
-
-          <!-- X axis labels -->
-              <text x="{{ left_margin }}" y="{{ (graph_height - bottom_margin) + 20 }}" text-anchor="start" style="font-size: 12px;">Week beginning {{ (data.weeks|last).week | format_friendly_short_date_with_year }}</text>
-          <text x="{{ graph_width - right_margin }}" y="{{ (graph_height - bottom_margin) + 20 }}" text-anchor="end" style="font-size: 12px;">Week beginning {{ (data.weeks|first).week | format_friendly_short_date_with_year }}</text>
+    {% if data.total_page_count_each_week|length > 1 %}
+    {% set x_scale = (graph_width - (left_margin + right_margin)) / (data.total_page_count_each_week|length - 1) %}
+    {% set y_scale = (graph_height - (top_margin + bottom_margin)) / (data.total_page_count_each_week|last) %}
 
 
-          <line x1="{{ left_margin }}" x2="{{ graph_width - right_margin }}" y1="{{ graph_height - bottom_margin }}" y2="{{ graph_height - bottom_margin }}" stroke="#e6e6e6" stroke-width="1"/>
+    <g transform="translate({{ left_margin }},-{{ bottom_margin }})">
+
+      <text x="0" y="{{ graph_height + 20 }}" text-anchor="start" style="font-size: 12px;">Week beginning {{ (data.weeks|last).week | format_friendly_short_date_with_year }}</text>
+
+      <text x="{{ graph_width - (left_margin + right_margin) }}" y="{{ graph_height + 20 }}" text-anchor="end" style="font-size: 12px;">Week beginning {{ (data.weeks|first).week | format_friendly_short_date_with_year }}</text>
+
+      <line x1="0" x2="{{ graph_width - (right_margin + left_margin) }}" y1="{{ graph_height }}" y2="{{ graph_height }}" stroke="#e6e6e6" stroke-width="1"/>
 
 
-          <!-- First value label -->
-          <text x="{{ left_margin }}" y="{{ (graph_height - bottom_margin) - ((data.cumulative_number_of_pages|first) * yScale) + 20 }}" text-anchor="start" style="font-size: 16px;">{{ data.cumulative_number_of_pages|first }} pages</text>
+      {# Cumulative number of pages #}
 
-          <!-- Last value label -->
-          <text x="{{ (graph_width - right_margin + 5) }}" y="{{ (graph_height - bottom_margin) - ((data.cumulative_number_of_pages|last) * yScale) - 13 }}" text-anchor="end" style="font-size: 16px;">{{ data.cumulative_number_of_pages|last }} pages</text>
+      {{ render_value_line(data.total_page_count_each_week, x_scale, y_scale, graph_height, colour="#2B8CC4") }}
 
-          <path d="
-          {% for value in data.cumulative_number_of_pages %}
-            {% if value != 0 %}
-              {% if loop.index0 == 0 %}M{% else %}L{% endif %}
-              {{ (loop.index0 * xScale) + left_margin + 0.5 }} {{ (graph_height - bottom_margin) - (value * yScale) }}
-            {% endif %}
+      {{ render_value_circles(data.total_page_count_each_week, x_scale, y_scale, graph_height) }}
 
-          {% endfor %}
-          " stroke-width="2" stroke="#2B8CC4" fill="none" />
+      {{ render_value_label(data.total_page_count_each_week|first, 0, x_scale, y_scale, graph_height, unit='pages')  }}
 
-          {% for value in data.cumulative_number_of_pages %}
-            <circle cx="{{ (loop.index0 * xScale) + left_margin + 0.5 }}" cy="{{ (graph_height - bottom_margin) - (value * yScale) }}" r="4" fill="#2B8CC4" />
-          {% endfor %}
+      {{ render_value_label(data.total_page_count_each_week|last, (data.total_page_count_each_week|length - 1), x_scale, y_scale, graph_height, text_anchor='end', vertical_offset=-13, unit='pages')  }}
 
 
-          {# Create the line for the cumulative number of updates, starting last zero
-             value before the line starts going up.
-           #}
-          <path d="
-          M{{ ((data.cumulative_number_of_major_updates|index_of_last_initial_zero + 1) * xScale) + left_margin + 0.5 }},{{ (graph_height - bottom_margin) - (0 * yScale) }}
-          {% for value in data.cumulative_number_of_major_updates %}
+      {# Cumulative number of major updates (starting with the first one) #}
 
-            {% if value != 0 %}
+      {{ render_value_line(data.total_major_updates_count_each_week, x_scale, y_scale, graph_height, colour='#28A197', start_index=data.total_major_updates_count_each_week|index_of_last_initial_zero) }}
 
-              L{{ (loop.index0 * xScale) + left_margin + 0.5 }} {{ (graph_height - bottom_margin) - (value * yScale) }}
-            {% endif %}
+      {{ render_value_circles(data.total_major_updates_count_each_week, x_scale, y_scale, graph_height, colour='#28A197', start_index=data.total_major_updates_count_each_week|index_of_last_initial_zero) }}
 
-          {% endfor %}
-          " stroke-width="2" stroke="#28A197" fill="none" />
+      {{ render_value_label(data.total_major_updates_count_each_week|last, (data.total_major_updates_count_each_week|length - 1), x_scale, y_scale, graph_height, text_anchor='end', vertical_offset=-13, unit='updates')  }}
 
+    </g>
 
-          {# Add circles at the points of all the non-zero values for the updates line #}
-          {% for value in data.cumulative_number_of_major_updates %}
-            {% if value != 0 %}
-              <circle cx="{{ (loop.index0 * xScale) + left_margin + 0.5 }}" cy="{{ (graph_height - bottom_margin) - (value * yScale) }}" r="4" fill="#28A197" />
-            {% endif %}
-          {% endfor %}
-
-          {# Text value for the last point in the updates #}
-          <text x="{{ (graph_width - right_margin + 5) }}" y="{{ (graph_height - bottom_margin) - ((data.cumulative_number_of_major_updates|last) * yScale) - 15 }}" text-anchor="end" style="font-size: 16px;">{{ data.cumulative_number_of_major_updates|last }} updates</text>
-
-
-          {% endif %}
-        </svg>
+    {% endif %}
+  </svg>
 
 {% endmacro %}

--- a/application/templates/dashboards/graphs.html
+++ b/application/templates/dashboards/graphs.html
@@ -4,9 +4,9 @@
 
           <rect width="{{ graph_width }}" height="{{ graph_height }}" x="0" y="0" fill="#F5F5F5" />
 
-          {% if data.graph_values|length > 1 %}
-          {% set xScale = (graph_width - (left_margin + right_margin)) / (data.graph_values|length - 1) %}
-          {% set yScale = (graph_height - (top_margin + bottom_margin)) / (data.graph_values|last) %}
+          {% if data.cumulative_number_of_pages|length > 1 %}
+          {% set xScale = (graph_width - (left_margin + right_margin)) / (data.cumulative_number_of_pages|length - 1) %}
+          {% set yScale = (graph_height - (top_margin + bottom_margin)) / (data.cumulative_number_of_pages|last) %}
 
 
 
@@ -17,23 +17,67 @@
 
           <line x1="{{ left_margin }}" x2="{{ graph_width - right_margin }}" y1="{{ graph_height - bottom_margin }}" y2="{{ graph_height - bottom_margin }}" stroke="#e6e6e6" stroke-width="1"/>
 
+
           <!-- First value label -->
-          <text x="{{ left_margin + 0.5 }}" y="{{ (graph_height - bottom_margin) - ((data.graph_values|first) * yScale) - 14 }}" text-anchor="middle" style="font-size: 16px;">{{ data.graph_values|first }}</text>
+          <text x="{{ left_margin }}" y="{{ (graph_height - bottom_margin) - ((data.cumulative_number_of_pages|first) * yScale) + 20 }}" text-anchor="start" style="font-size: 16px;">{{ data.cumulative_number_of_pages|first }} pages</text>
 
           <!-- Last value label -->
-          <text x="{{ (graph_width - (right_margin + 0.5)) }}" y="{{ (graph_height - bottom_margin) - ((data.graph_values|last) * yScale) - 13 }}" text-anchor="middle" style="font-size: 16px;">{{ data.graph_values|last }}</text>
+          <text x="{{ (graph_width - right_margin + 5) }}" y="{{ (graph_height - bottom_margin) - ((data.cumulative_number_of_pages|last) * yScale) - 13 }}" text-anchor="end" style="font-size: 16px;">{{ data.cumulative_number_of_pages|last }} pages</text>
 
           <path d="
-          {% for value in data.graph_values %}
-            {% if loop.index0 == 0 %}M{% else %}L{% endif %}
-            {{ (loop.index0 * xScale) + left_margin + 0.5 }} {{ (graph_height - bottom_margin) - (value * yScale) }}
+          {% for value in data.cumulative_number_of_pages %}
+            {% if value != 0 %}
+              {% if loop.index0 == 0 %}M{% else %}L{% endif %}
+              {{ (loop.index0 * xScale) + left_margin + 0.5 }} {{ (graph_height - bottom_margin) - (value * yScale) }}
+            {% endif %}
 
           {% endfor %}
           " stroke-width="2" stroke="#2B8CC4" fill="none" />
 
-          {% for value in data.graph_values %}
+          {% for value in data.cumulative_number_of_pages %}
             <circle cx="{{ (loop.index0 * xScale) + left_margin + 0.5 }}" cy="{{ (graph_height - bottom_margin) - (value * yScale) }}" r="4" fill="#2B8CC4" />
           {% endfor %}
+
+          {# Set the last_non_zero_index variable to be the index of the
+             the last value which is a zero, so that we can use that to start the
+             graph from there, rather than showing a line along the bottom.
+           #}
+          {% set ns = namespace(last_non_zero_index = 0) %}
+          {% for value in data.cumulative_number_of_major_updates %}
+
+            {% if value == 0 %}
+              {% set ns.last_non_zero_index = loop.index0 %}
+            {% endif %}
+
+          {% endfor %}
+
+
+          {# Create the line for the cumalative number of updates, starting last zero
+             value before the line starts going up.
+           #}
+          <path d="
+          M{{ ((ns.last_non_zero_index + 1) * xScale) + left_margin + 0.5 }},{{ (graph_height - bottom_margin) - (0 * yScale) }}
+          {% for value in data.cumulative_number_of_major_updates %}
+
+            {% if value != 0 %}
+
+              L{{ (loop.index0 * xScale) + left_margin + 0.5 }} {{ (graph_height - bottom_margin) - (value * yScale) }}
+            {% endif %}
+
+          {% endfor %}
+          " stroke-width="2" stroke="#28A197" fill="none" />
+
+
+          {# Add circles at the points of all the non-zero values for the updates line #}
+          {% for value in data.cumulative_number_of_major_updates %}
+            {% if value != 0 %}
+              <circle cx="{{ (loop.index0 * xScale) + left_margin + 0.5 }}" cy="{{ (graph_height - bottom_margin) - (value * yScale) }}" r="4" fill="#28A197" />
+            {% endif %}
+          {% endfor %}
+
+          {# Text value for the last point in the updates #}
+          <text x="{{ (graph_width - right_margin + 5) }}" y="{{ (graph_height - bottom_margin) - ((data.cumulative_number_of_major_updates|last) * yScale) - 15 }}" text-anchor="end" style="font-size: 16px;">{{ data.cumulative_number_of_major_updates|last }} updates</text>
+
 
           {% endif %}
         </svg>

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -39,7 +39,7 @@
           {{ render_line_graph(data=data,
                                graph_height=220,
                                graph_width=630,
-                               left_margin=50,
+                               left_margin=20,
                                right_margin=20,
                                top_margin=40,
                                bottom_margin=40) }}

--- a/application/templates/dashboards/publications.html
+++ b/application/templates/dashboards/publications.html
@@ -24,12 +24,12 @@
 
     <div class="grid-row">
       <div class="column-one-third">
-        <div class="stat">
+        <div class="stat background-light-blue">
           <span class="bold-xlarge">{{ data.number_of_publications }}</span>
           <span class="">{% if data.number_of_publications == 1 %}Page{% else %}Pages{% endif %}</span>
         </div>
 
-        <div class="stat">
+        <div class="stat background-turquoise">
           <span class="bold-xlarge">{{ data.number_of_major_updates }}</span>
           <span class="">{% if data.number_of_major_updates == 1 %}Update{% else %}Updates{% endif %}</span>
         </div>

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -20,20 +20,19 @@ class TestRenderMarkdown:
 
 
 class TestIndexOfLastInitialZero:
-
     def test_when_only_one_zero(self):
-        assert index_of_last_initial_zero([0,10,20]) == 0
+        assert index_of_last_initial_zero([0, 10, 20]) == 0
 
     def test_when_many_zeros(self):
-        assert index_of_last_initial_zero([0,0,0,0,1,2]) == 3
+        assert index_of_last_initial_zero([0, 0, 0, 0, 1, 2]) == 3
 
     def test_when_later_zeros_are_present(self):
-        assert index_of_last_initial_zero([0,0,1,2,1,0]) == 1
+        assert index_of_last_initial_zero([0, 0, 1, 2, 1, 0]) == 1
 
     def test_when_no_zeros_are_present(self):
         with pytest.raises(ValueError):
-            index_of_last_initial_zero([1,2,3,4])
+            index_of_last_initial_zero([1, 2, 3, 4])
 
     def test_when_array_contains_strings(self):
         with pytest.raises(ValueError):
-            index_of_last_initial_zero(['0','1','2'])
+            index_of_last_initial_zero(["0", "1", "2"])

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -1,6 +1,7 @@
 import pytest
 
 from application.static_site.filters import render_markdown
+from application.cms.filters import index_of_last_initial_zero
 
 
 class TestRenderMarkdown:
@@ -16,3 +17,23 @@ class TestRenderMarkdown:
     )
     def test_html_is_escaped(self, input_text, expected_output):
         assert render_markdown(input_text) == expected_output
+
+
+class TestIndexOfLastInitialZero:
+
+    def test_when_only_one_zero(self):
+        assert index_of_last_initial_zero([0,10,20]) == 0
+
+    def test_when_many_zeros(self):
+        assert index_of_last_initial_zero([0,0,0,0,1,2]) == 3
+
+    def test_when_later_zeros_are_present(self):
+        assert index_of_last_initial_zero([0,0,1,2,1,0]) == 1
+
+    def test_when_no_zeros_are_present(self):
+        with pytest.raises(ValueError):
+            index_of_last_initial_zero([1,2,3,4])
+
+    def test_when_array_contains_strings(self):
+        with pytest.raises(ValueError):
+            index_of_last_initial_zero(['0','1','2'])


### PR DESCRIPTION
This redesigns the [pages published by week](https://www.ethnicity-facts-figures.service.gov.uk/dashboards/published) dashboard by separating out "updates" and "new pages" onto separate lines:

<img width="983" alt="screen shot 2018-10-12 at 15 45 18" src="https://user-images.githubusercontent.com/30665/46876581-99482c80-ce36-11e8-889f-3ff77f29950d.png">

See https://trello.com/c/TAhR3l9m/1094-show-separate-lines-for-new-and-updates-on-the-published-pages-dashboard