### PR TITLE
Order pages in the database

### DIFF
--- a/application/cms/page_service.py
+++ b/application/cms/page_service.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, date
 
 from slugify import slugify
+from sqlalchemy import desc
 from sqlalchemy.orm import make_transient
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -172,7 +173,7 @@ class PageService(Service):
 
     @staticmethod
     def get_measure_page_versions(parent_guid, measure_uri):
-        return Page.query.filter_by(parent_guid=parent_guid, uri=measure_uri).all()
+        return Page.query.filter_by(parent_guid=parent_guid, uri=measure_uri).order_by(desc(Page.version)).all()
 
     def get_page_with_version(self, guid, version):
         try:
@@ -263,7 +264,7 @@ class PageService(Service):
         try:
             topic = Page.query.filter_by(uri=topic_uri).one()
             subtopic = Page.query.filter_by(uri=subtopic_uri, parent_guid=topic.guid).one()
-            pages = Page.query.filter_by(uri=measure_uri, parent_guid=subtopic.guid).all()
+            pages = Page.query.filter_by(uri=measure_uri, parent_guid=subtopic.guid).order_by(desc(Page.version)).all()
             if len(pages) > 0:
                 return pages[0]
             else:
@@ -388,7 +389,7 @@ class PageService(Service):
 
     @staticmethod
     def get_pages_by_type(page_type):
-        return Page.query.filter_by(page_type=page_type).all()
+        return Page.query.filter_by(page_type=page_type).order_by(Page.title, desc(Page.version)).all()
 
     @staticmethod
     def get_latest_publishable_measures(subtopic):
@@ -407,7 +408,7 @@ class PageService(Service):
 
     @staticmethod
     def get_pages_by_uri(subtopic, measure):
-        return Page.query.filter_by(parent_guid=subtopic, uri=measure).all()
+        return Page.query.filter_by(parent_guid=subtopic, uri=measure).order_by(desc(Page.version)).all()
 
     @staticmethod
     def set_type_of_data(page, data):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from application.data.standardisers.ethnicity_dictionary_lookup import Ethnicity
 from application.cms.models import *
 from application.cms.scanner_service import ScannerService
 from application.cms.upload_service import UploadService
+from application.cms.page_service import PageService
 from application.config import TestConfig
 from application.factory import create_app
 from manage import refresh_materialized_views
@@ -773,3 +774,10 @@ def upload_service(app):
     upload_service.init_app(app)
     upload_service.enabled = True
     return upload_service
+
+
+@pytest.fixture(scope="function")
+def page_service(app):
+    page_service = PageService()
+    page_service.init_app(app)
+    return page_service

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -4,6 +4,8 @@ from bs4 import BeautifulSoup
 from application.cms.exceptions import RejectionImpossible
 from application.cms.models import Page
 
+from tests.utils import create_measure_page_versions
+
 
 def test_publish_to_internal_review(stub_topic_page):
     assert stub_topic_page.status == "DRAFT"
@@ -339,3 +341,70 @@ def test_is_minor_or_minor_version():
     assert page.version == "2.0"
     assert page.is_major_version() is True
     assert page.is_minor_version() is False
+
+
+@pytest.mark.parametrize(
+    "page_versions, expected_order",
+    (
+        (["1.0", "1.1", "1.2", "2.0"], ["2.0", "1.2", "1.1", "1.0"]),
+        (["2.0", "1.2", "1.1", "1.0"], ["2.0", "1.2", "1.1", "1.0"]),
+    ),
+)
+def test_get_measure_page_versions_returns_pages_ordered_by_version(
+    db_session, page_service, stub_measure_page, page_versions, expected_order
+):
+    create_measure_page_versions(db_session, stub_measure_page, page_versions)
+
+    assert [
+        page.version
+        for page in page_service.get_measure_page_versions(
+            parent_guid=stub_measure_page.parent.guid, measure_uri="test-measure-page-2"
+        )
+    ] == expected_order
+
+
+@pytest.mark.parametrize(
+    "page_versions, expected_version", ((["1.0", "1.1", "1.2", "2.0"], "2.0"), (["2.0", "1.2", "1.1", "1.0"], "2.0"))
+)
+def test_get_latest_version_returns_latest_measure_page(
+    db_session, page_service, stub_measure_page, page_versions, expected_version
+):
+    create_measure_page_versions(db_session, stub_measure_page, page_versions)
+
+    assert (
+        page_service.get_latest_version(
+            topic_uri=stub_measure_page.parent.parent.uri,
+            subtopic_uri=stub_measure_page.parent.uri,
+            measure_uri="test-measure-page-2",
+        ).version
+        == expected_version
+    )
+
+
+@pytest.mark.parametrize(
+    "page_versions, expected_order", ((["1.0", "2.0"], ["1.0", "2.0", "1.0"]), (["2.0", "1.0"], ["1.0", "2.0", "1.0"]))
+)
+def test_get_pages_by_type_returns_pages_ordered_by_title_and_version(
+    db_session, page_service, stub_measure_page, page_versions, expected_order
+):
+    create_measure_page_versions(db_session, stub_measure_page, page_versions)
+
+    pages = page_service.get_pages_by_type("measure")
+    assert [page.title for page in pages] == ["Test Measure Page", "Test measure page 2", "Test measure page 2"]
+    assert [page.version for page in pages] == expected_order
+
+
+@pytest.mark.parametrize(
+    "page_versions, expected_order",
+    (
+        (["1.0", "1.1", "1.2", "2.0"], ["2.0", "1.2", "1.1", "1.0"]),
+        (["2.0", "1.2", "1.1", "1.0"], ["2.0", "1.2", "1.1", "1.0"]),
+    ),
+)
+def test_get_pages_by_uri_returns_pages_ordered_by_version(
+    db_session, page_service, stub_measure_page, page_versions, expected_order
+):
+    create_measure_page_versions(db_session, stub_measure_page, page_versions)
+
+    pages = page_service.get_pages_by_uri(stub_measure_page.parent.guid, "test-measure-page-2")
+    assert [page.version for page in pages] == expected_order

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,8 +13,11 @@ class UnexpectedMockInvocationException(GeneralTestException):
     pass
 
 
-def create_measure_page_versions(db, example_measure_page, required_versions):
-    for page_version in required_versions:
+def create_measure_page_versions(db, example_measure_page, required_versions, required_titles=None):
+    if not required_titles:
+        required_titles = [f"Test {version}" for version in required_versions]
+
+    for page_version, page_title in zip(required_versions, required_titles):
         page = Page(
             guid="test",
             version=page_version,
@@ -22,7 +25,7 @@ def create_measure_page_versions(db, example_measure_page, required_versions):
             parent_version=example_measure_page.parent.version,
             page_type="measure",
             uri="test-measure-page-2",
-            title="Test measure page 2",
+            title=page_title,
             status="APPROVED",
         )
         db.session.add(page)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,6 @@
+from application.cms.models import Page
+
+
 class GeneralTestException(Exception):
     pass
 
@@ -8,3 +11,20 @@ class UnmockedRequestException(GeneralTestException):
 
 class UnexpectedMockInvocationException(GeneralTestException):
     pass
+
+
+def create_measure_page_versions(db, example_measure_page, required_versions):
+    for page_version in required_versions:
+        page = Page(
+            guid="test",
+            version=page_version,
+            parent_guid=example_measure_page.parent.guid,
+            parent_version=example_measure_page.parent.version,
+            page_type="measure",
+            uri="test-measure-page-2",
+            title="Test measure page 2",
+            status="APPROVED",
+        )
+        db.session.add(page)
+
+    db.session.commit()


### PR DESCRIPTION
 ## Summary
We have some helper methods on `page_service` that return a list of
pages from the database. Some of these methods return pages in an
undefined order because they do not specify an order clause when
querying the database. This makes it easy for developers to forget to
order the results manually.

The safest solution here is to order the `.all()` Page queries
explicitly - and once only - in the page service. All callers can then
rely on it being in a specific order. If they need it in a different
order, they can sort it manually.

This lack of ordering caused a bug where some measure pages were
incorrectly showing the "There is a newer version of this measure"
banner at the top of the page, because we were simply grabbing the first
measure page from the result set and expected it to be the latest
version.

 ## Ticket
https://trello.com/c/hg97gPCJ/1151