### PR TITLE
Add coveralls support

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,7 @@
 attrs==18.1.0         # Required by pytest
 click==6.7
 coverage==4.5.1       # Required by pytest-cov
+coveralls==1.5.1
 Faker==0.8.15
 glob2==0.6
 pluggy==0.6.0         # Required by pytest

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,5 +31,10 @@ display_result $? 1 "Code style check"
 npx gulp
 display_result $? 2 "Frontend asset build check"
 
-py.test
-display_result $? 3 "Python tests"
+py.test --cov application/ --cov-report term-missing
+pytest_exitcode=$?
+
+display_result ${pytest_exitcode} 3 "Python tests"
+if [[ "${pytest_exitcode}" == "0" ]]; then
+  coveralls
+fi


### PR DESCRIPTION
 ## Summary
This patch adds coveralls reporting to our repository, which should let
us understand the current state of codebase coverage and enforce that
new code needs to come with appropriate test coverage.

Also adds a badge to the README for `landscape.io`, which supposedly
provides code quality checks for Python. We'll see.